### PR TITLE
Refactor CONFIG_PATH to use env variable with fallback to default settings.json

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -22,7 +22,10 @@ except ImportError:
 
 SERIAL_PORT = '/dev/ttyUSB0'
 BAUD_RATE = 9600
-CONFIG_PATH = "/home/gordo/splitflap/settings.json"
+CONFIG_PATH = os.environ.get(
+    "SPLITFLAP_CONFIG",
+    os.path.join(os.path.dirname(__file__), "settings.json")
+)
 PLUGIN_APPS_PATH = os.path.expanduser("~/.splitflap/apps")
 BUILTIN_APPS_PATH = os.path.join(os.path.dirname(__file__), '..', 'apps')
 


### PR DESCRIPTION
This pull request makes config loading portable across Raspberry Pi and PC development environments.

### Instead of relying on a Pi-only hardcoded path, `CONFIG_PATH` now:

Uses `SPLITFLAP_CONFIG` when explicitly provided (best for production/deploy control)
Falls back to a local settings.json next to the server code for zero-setup local dev

### Why this matters:

Prevents path breakage when running on Windows/macOS/Linux during development
Keeps Pi deployments configurable without changing code
Reduces environment-specific edits and branch drift between “Pi” and “PC dev” setups