### PR TITLE
Add floating save button and settings dirty state management

### DIFF
--- a/server/static/app.js
+++ b/server/static/app.js
@@ -1024,6 +1024,7 @@ function loadSettingsData(){
     document.getElementById('simCols').value = data.sim_cols||15;
     renderModuleGrid();
     selectModule(selectedModule);
+    setSettingsDirty(false);
   });
 }
 
@@ -1156,6 +1157,12 @@ function modalAction(action){
   });
 }
 
+function setSettingsDirty(isDirty){
+  const fab = document.getElementById('settingsFab');
+  if(!fab) return;
+  fab.classList.toggle('visible', !!isDirty);
+}
+
 function saveGlobal(){
   const rows = parseInt(document.getElementById('simRows').value) || 3;
   const cols = parseInt(document.getElementById('simCols').value) || 15;
@@ -1175,6 +1182,7 @@ function saveGlobal(){
   })}).then(()=>{
     initLiveGrids(rows, cols);
     showToast('Settings saved');
+    setSettingsDirty(false);
   });
 }
 
@@ -1650,6 +1658,15 @@ function tmFinishEarly(){
   const sel = document.getElementById('styleInput');
   if(sel) sel.innerHTML = buildStyleOptions('ltr');
 })();
+
+document.querySelectorAll('button[onclick="saveGlobal()"]:not(#settingsFab)').forEach(el => el.remove());
+
+const settingsPage = document.getElementById('page-settings');
+if(settingsPage){
+  settingsPage.addEventListener('input', (e) => {
+    if(e.target.closest('.settings-grid')) setSettingsDirty(true);
+  });
+}
 
 buildAppsGrid();
 loadSavedPlaylists();

--- a/server/static/styles.css
+++ b/server/static/styles.css
@@ -234,3 +234,11 @@ input:checked+.slider:before{transform:translateX(20px)}
   .apps-grid{grid-template-columns:repeat(2,1fr)}
   .char-matrix{grid-template-columns:repeat(5,1fr)}
 }
+
+/* ── SETTINGS FLOATING SAVE FAB ── */
+.settings-fab{position:fixed;left:32px;right:32px;max-width:756px;margin:0 auto;bottom:20px;transform:translateY(20px);background:var(--green);color:#fff;border:none;border-radius:28px;padding:12px 28px;font-size:.95rem;font-weight:700;cursor:pointer;box-shadow:0 4px 18px rgba(0,0,0,.45);opacity:0;pointer-events:none;transition:opacity .22s ease,transform .22s ease;z-index:150;display:flex;align-items:center;justify-content:center;gap:8px}
+.settings-fab.visible{opacity:1;pointer-events:auto;transform:translateY(0)}
+
+@media(max-width:600px){
+  .settings-fab{left:42px;right:42px}
+}

--- a/server/templates/index.html
+++ b/server/templates/index.html
@@ -207,7 +207,7 @@
         <div class="span2"><label class="field-label">YouTube Data API Key</label><input type="password" id="ytApiInput" class="line-input" style="font-size:.95rem;margin:0"></div>
         <div class="span2"><label class="field-label">YouTube Video ID (for Comments)</label><input type="text" id="ytVideoInput" class="line-input" style="font-size:.95rem;margin:0"></div>
       </div>
-      <button class="btn btn-secondary" style="margin-top:14px" onclick="saveGlobal()">Save Settings</button>
+  <button class="settings-fab" id="settingsFab" onclick="saveGlobal()"><i data-lucide="save" style="width:16px;height:16px"></i> Save Settings</button>
     </div>
     <div class="config-section">
       <h3>Backup &amp; Restore</h3>


### PR DESCRIPTION
This pull request updates the settings page UI to improve the user experience when saving settings. It introduces a floating "Save Settings" button (FAB) that appears only when there are unsaved changes, and removes the previous static save button. The main logic tracks changes in the settings form and updates the FAB's visibility accordingly.

**Settings Save UI Improvements:**

* Added a floating "Save Settings" button (`settings-fab`) that appears at the bottom of the settings page when there are unsaved changes. [[1]](diffhunk://#diff-6d6d80a34fdd2395df72772d5d368c9837e87b92b5074cdd4b99547aa8abaa05L210-R210) [[2]](diffhunk://#diff-28fd0c0533a3958e0fd86ec93b47e38e2c9221e2c42b75b276da528c85295bd2R237-R244)
* Removed the old static "Save Settings" button from the settings page. [[1]](diffhunk://#diff-b00398f81bc55184de2a858bf419d242def77cfe797a17b7d3b5b54b62cef5c1R1662-R1670) [[2]](diffhunk://#diff-6d6d80a34fdd2395df72772d5d368c9837e87b92b5074cdd4b99547aa8abaa05L210-R210)

**Change Tracking Logic:**

* Implemented the `setSettingsDirty(isDirty)` function to toggle the FAB's visibility based on whether settings have been modified.
* Added event listeners to the settings form to detect input changes and show the FAB when necessary.
* Automatically hides the FAB after settings are loaded or successfully saved, ensuring the button only appears when there are unsaved changes. [[1]](diffhunk://#diff-b00398f81bc55184de2a858bf419d242def77cfe797a17b7d3b5b54b62cef5c1R1027) [[2]](diffhunk://#diff-b00398f81bc55184de2a858bf419d242def77cfe797a17b7d3b5b54b62cef5c1R1185)