### PR TITLE
Enhance app card layout with action buttons and improved styling

### DIFF
--- a/server/static/app.js
+++ b/server/static/app.js
@@ -808,13 +808,13 @@ function appLucideIcon(key){
 
 function buildAppCard(a, isPlugin) {
   const div = document.createElement('div');
-  div.className = 'app-card';
-  div.dataset.app = a.key;
-  div.onclick = () => runApp(a.key);
   const bareKey = a.key.replace('plugin_','');
   const cfgKey = bareKey in APP_SETTINGS_CONFIG ? bareKey : a.key;
   const hasCfg = APP_SETTINGS_CONFIG[cfgKey] && (APP_SETTINGS_CONFIG[cfgKey].fields||[]).length > 0;
   const removable = isPlugin;
+  div.className = 'app-card has-app-actions';
+  div.dataset.app = a.key;
+  div.onclick = () => runApp(a.key);
   const icon = appLucideIcon(a.key) || appLucideIcon(a.plugin_id||'') || `<span style="font-size:2.2rem">${a.icon}</span>`;
   div.innerHTML = `
     ${hasCfg ? `<button class="app-gear" style="right:${removable?'28':'8'}px" title="Settings" onclick="event.stopPropagation();openAppSettings('${cfgKey}')"><i data-lucide="settings" style="width:14px;height:14px"></i></button>` : ''}
@@ -867,7 +867,7 @@ async function loadAppLibrary(){
     apps.sort((a,b) => (a.installed===b.installed) ? (a.name||'').localeCompare(b.name||'') : a.installed ? 1 : -1);
     apps.forEach(a => {
       const div = document.createElement('div');
-      div.className = 'app-card';
+      div.className = 'app-card app-library-card';
       div.style.cursor = 'default';
       const icon = appLucideIcon(a.id) || `<span style="font-size:2.2rem">${a.icon||'🧩'}</span>`;
       div.innerHTML = `
@@ -875,7 +875,7 @@ async function loadAppLibrary(){
         <span class="app-name">${a.name}</span>
         <span class="app-desc">${a.description||''}</span>
         <span style="display:inline-block;font-size:.65rem;color:#888;background:#222;padding:2px 6px;border-radius:4px;margin-top:4px">${a.type}${a.version?' · v'+a.version:''}</span>
-        <div style="margin-top:8px">
+        <div class="app-library-action">
           ${a.installed
             ? '<button class="btn-del" style="width:100%;padding:8px;border-radius:6px;font-size:.8rem" onclick="event.stopPropagation();uninstallApp(\''+a.id+'\')">Uninstall</button>'
             : '<button class="btn btn-success btn-sm" style="width:100%" onclick="event.stopPropagation();installApp(\''+a.id+'\')">Install</button>'

--- a/server/static/styles.css
+++ b/server/static/styles.css
@@ -113,14 +113,17 @@ h3{margin-top:0;color:var(--text)}
 /* ── APPS GRID ── */
 .apps-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(130px,1fr));gap:12px;margin-top:16px}
 .app-card{background:var(--panel);border:1px solid var(--border);border-radius:12px;padding:20px 12px 16px;text-align:center;cursor:pointer;transition:all .2s;position:relative}
+.app-card.has-app-actions{padding-top:28px}
 .app-card:hover{border-color:var(--accent);background:#252525;transform:translateY(-2px)}
 .app-card.running{border-color:var(--green);background:#1a2a1a}
-.app-card.running::after{content:'▶ LIVE';position:absolute;top:6px;left:8px;font-size:.65rem;color:var(--green);font-weight:bold;letter-spacing:.5px}
+.app-card.running::after{content:'▶ LIVE';position:absolute;top:6px;left:12px;font-size:.65rem;color:var(--green);font-weight:bold;letter-spacing:.5px;line-height:1;display:flex;align-items:center;height:18px}
 .app-icon{font-size:2.2rem;display:block;margin-bottom:8px}
 .app-name{font-weight:bold;display:block;margin-bottom:3px;font-size:.9rem}
 .app-desc{font-size:.72rem;color:var(--text-muted)}
 .app-gear{position:absolute;top:6px;right:8px;background:none;border:none;color:#555;cursor:pointer;font-size:1rem;padding:2px 4px;border-radius:4px;transition:.15s}
 .app-gear:hover{color:#ccc;background:#333}
+.app-library-card{display:flex;flex-direction:column}
+.app-library-action{margin-top:auto;padding-top:8px}
 
 /* ── TUNING ── */
 .config-section{background:var(--panel);padding:20px;border-radius:12px;margin-bottom:28px;border:1px solid var(--border)}
@@ -210,6 +213,7 @@ input:checked+.slider:before{transform:translateX(20px)}
   .preview-wrapper{padding:7px}
   .apps-grid{grid-template-columns:repeat(3,1fr);gap:8px}
   .app-card{padding:14px 6px 12px}
+  .app-card.has-app-actions{padding-top:26px}
   .app-icon{font-size:1.7rem;margin-bottom:4px}
   .app-name{font-size:.75rem}
   .app-desc{display:none}


### PR DESCRIPTION
This pull request updates the visual layout and styling of app cards in the application grid and app library. The changes primarily focus on improving the display of action buttons, adjusting padding, and enhancing the visual distinction between different card types.

_(Basically fixes alignment of elements within the cards when looking at it in the grid list and fixes overlapping of the cog on mobile)_

**App card and library layout improvements:**

* Added a new class `.has-app-actions` to `app-card` elements in `buildAppCard`, increasing the top padding to make space for action buttons and improving the card's visual structure. [[1]](diffhunk://#diff-b00398f81bc55184de2a858bf419d242def77cfe797a17b7d3b5b54b62cef5c1L811-R817) [[2]](diffhunk://#diff-28fd0c0533a3958e0fd86ec93b47e38e2c9221e2c42b75b276da528c85295bd2R116-R126) [[3]](diffhunk://#diff-28fd0c0533a3958e0fd86ec93b47e38e2c9221e2c42b75b276da528c85295bd2R216)
* Updated the app library cards to use a new class `.app-library-card` and wrapped action buttons in a `.app-library-action` container for better alignment and spacing. [[1]](diffhunk://#diff-b00398f81bc55184de2a858bf419d242def77cfe797a17b7d3b5b54b62cef5c1L870-R878) [[2]](diffhunk://#diff-28fd0c0533a3958e0fd86ec93b47e38e2c9221e2c42b75b276da528c85295bd2R116-R126)
* Enhanced the `.app-card.running::after` pseudo-element for better placement and appearance of the "LIVE" indicator.

These changes collectively improve the usability and appearance of app cards and the app library, making action buttons more accessible and the overall interface more visually consistent.