### PR TITLE
Add search+chip pickers for app settings

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -2174,6 +2174,85 @@ def sports_follow():
     save_settings(settings)
     return jsonify(status='success')
 
+# ============================================================
+#  SEARCH ENDPOINTS (timezone, stocks, crypto)
+# ============================================================
+
+@app.route('/timezones')
+def timezones_route():
+    """Search timezones with common ones first."""
+    query = request.args.get('q', '').strip().lower()
+    common = ['US/Eastern','US/Central','US/Mountain','US/Pacific','US/Hawaii',
+              'Europe/London','Europe/Paris','Europe/Berlin','Asia/Tokyo','Asia/Shanghai',
+              'Australia/Sydney','Pacific/Auckland','America/Chicago','America/Denver',
+              'America/Los_Angeles','America/New_York','America/Toronto','America/Sao_Paulo']
+    all_zones = pytz.common_timezones
+    results = []
+    seen = set()
+    def add_zone(tz):
+        if tz in seen: return
+        seen.add(tz)
+        try:
+            offset = datetime.now(pytz.timezone(tz)).strftime('%z')
+            label = f"{tz} (UTC{offset[:3]}:{offset[3:]})"
+        except Exception:
+            label = tz
+        results.append({'value': tz, 'label': label})
+    if not query:
+        for tz in common: add_zone(tz)
+    else:
+        for tz in common:
+            if query in tz.lower(): add_zone(tz)
+        for tz in all_zones:
+            if query in tz.lower(): add_zone(tz)
+    return jsonify(zones=results[:20])
+
+@app.route('/stocks_search')
+def stocks_search_route():
+    """Search stock tickers via Yahoo Finance autocomplete."""
+    query = request.args.get('q', '').strip()
+    if len(query) < 1:
+        return jsonify(tickers=[])
+    try:
+        url = f"https://query2.finance.yahoo.com/v1/finance/search?q={query}&quotesCount=8&newsCount=0&enableFuzzyQuery=false&quotesQueryId=tss_match_phrase_query"
+        data = requests.get(url, timeout=5, headers={'User-Agent':'Mozilla/5.0'}).json()
+        tickers = []
+        for q in data.get('quotes', []):
+            sym = q.get('symbol', '')
+            name = q.get('shortname') or q.get('longname') or ''
+            if sym:
+                tickers.append({'value': sym, 'label': f"{sym} — {name}" if name else sym})
+        return jsonify(tickers=tickers)
+    except Exception as e:
+        logging.error(f"Stock search error: {e}")
+        return jsonify(tickers=[], error=str(e)), 502
+
+_crypto_cache = []
+
+@app.route('/crypto_search')
+def crypto_search_route():
+    """Search CoinGecko coins (cached)."""
+    global _crypto_cache
+    query = request.args.get('q', '').strip().lower()
+    if len(query) < 1:
+        return jsonify(coins=[])
+    if not _crypto_cache:
+        try:
+            data = requests.get('https://api.coingecko.com/api/v3/coins/list', timeout=10).json()
+            _crypto_cache = [{'id': c['id'], 'symbol': c['symbol'].upper(), 'name': c['name']} for c in data]
+        except Exception as e:
+            logging.error(f"CoinGecko fetch error: {e}")
+            return jsonify(coins=[], error=str(e)), 502
+    results = []
+    for c in _crypto_cache:
+        if query in c['name'].lower() or query in c['symbol'].lower() or query in c['id']:
+            results.append({'value': c['id'], 'label': f"{c['name']} ({c['symbol']})",
+                            '_exact': c['id']==query or c['name'].lower()==query or c['symbol'].lower()==query})
+            if len(results) >= 30: break
+    results.sort(key=lambda r: (not r['_exact'], r['label'].lower()))
+    for r in results: del r['_exact']
+    return jsonify(coins=results[:12])
+
 @app.route('/installed_apps')
 def installed_apps():
     return jsonify(

--- a/server/static/app.js
+++ b/server/static/app.js
@@ -14,14 +14,14 @@ const APP_SETTINGS_CONFIG = {
   weather:    { title:'🌤️ Weather Settings', fields:[
     {key:'zip_code',            label:'Zip Code',              type:'text',     ph:'02118'},
     {key:'weather_api_key',     label:'OpenWeatherMap API Key', type:'password', ph:'...'},
-    {key:'timezone',            label:'Timezone',              type:'text',     ph:'US/Eastern'},
+    {key:'timezone',            label:'Timezone',              type:'search_chips', searchUrl:'/timezones', resultKey:'zones', maxItems:1},
   ]},
   metro:      { title:'🚇 Metro Settings', fields:[
     {key:'mbta_stop',  label:'Stop ID (e.g. place-NSTAT)',  type:'text', ph:'place-NSTAT'},
     {key:'mbta_route', label:'Route (e.g. Orange)',          type:'text', ph:'Orange'},
   ]},
   stocks:     { title:'📈 Stocks Settings', fields:[
-    {key:'stocks_list', label:'Tickers (comma-separated)', type:'text', ph:'MSFT,GOOG,NVDA'},
+    {key:'stocks_list', label:'Stock Tickers', type:'search_chips', searchUrl:'/stocks_search', resultKey:'tickers'},
   ]},
   youtube:    { title:'▶️ YouTube Settings', fields:[
     {key:'yt_channel_id', label:'Channel ID', type:'text', ph:'UC...'},
@@ -33,12 +33,13 @@ const APP_SETTINGS_CONFIG = {
   countdown:  { title:'⏳ Countdown Settings', fields:[
     {key:'countdown_event',  label:'Event Name (15 chars)', type:'text',          ph:'NEW YEAR'},
     {key:'countdown_target', label:'Target Date & Time',    type:'datetime-local', ph:''},
+    {key:'timezone',         label:'Timezone',              type:'search_chips', searchUrl:'/timezones', resultKey:'zones', maxItems:1},
   ]},
   world_clock:{ title:'🌍 World Clock Settings', fields:[
-    {key:'world_clock_zones', label:'Timezones — comma-separated\n(e.g. US/Eastern, Europe/London, Asia/Tokyo)', type:'text', ph:'US/Eastern,US/Pacific,Europe/London'},
+    {key:'world_clock_zones', label:'Timezones (max 3)', type:'search_chips', searchUrl:'/timezones', resultKey:'zones', maxItems:3},
   ]},
   crypto:     { title:'₿ Crypto Settings', fields:[
-    {key:'crypto_list', label:'CoinGecko IDs (comma-separated)', type:'text', ph:'bitcoin,ethereum,solana'},
+    {key:'crypto_list', label:'Cryptocurrencies', type:'search_chips', searchUrl:'/crypto_search', resultKey:'coins'},
   ]},
   iss:        { title:'🛸 ISS Tracker', fields:[] },
   demo:       { title:'🎬 Demo Mode', fields:[] },
@@ -48,7 +49,7 @@ const APP_SETTINGS_CONFIG = {
     {key:'yt_channel_id', label:'YouTube Channel ID (for subs)', type:'text', ph:'UC...'},
     {key:'yt_video_id',   label:'YouTube Video ID (live, for viewers)', type:'text', ph:'...'},
     {key:'yt_api_key',    label:'YouTube Data API Key', type:'password', ph:'...'},
-    {key:'timezone',      label:'Timezone', type:'text', ph:'US/Eastern'},
+    {key:'timezone',      label:'Timezone', type:'search_chips', searchUrl:'/timezones', resultKey:'zones', maxItems:1},
   ]},
   anim_rainbow:{ title:'🌈 Rainbow Settings', fields:[
     {key:'anim_style', label:'Update Order', type:'select',
@@ -951,6 +952,20 @@ async function openAppSettings(appKey){
         input.rows = 8;
         if(f.ph) input.placeholder = f.ph;
         input.value = globalSettings[f.key]||'';
+      } else if(f.type==='search_chips'){
+        const wrapper = document.createElement('div');
+        wrapper.className = 'chip-picker';
+        div.appendChild(wrapper);
+        fields.appendChild(div);
+        createSearchChipPicker({
+          container: wrapper,
+          hiddenId: `asf_${f.key}`,
+          searchUrl: f.searchUrl,
+          resultKey: f.resultKey,
+          maxItems: f.maxItems||null,
+          currentValues: globalSettings[f.key]||''
+        });
+        return;
       } else {
         input = document.createElement('input');
         input.type = f.type||'text';
@@ -986,6 +1001,78 @@ function saveAppSettings(){
   });
   fetch('/settings',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(payload)})
   .then(()=>{ showToast('Settings saved'); closeAppSettings(); });
+}
+
+// ============================================================
+//  SEARCH + CHIP PICKER COMPONENT
+// ============================================================
+function createSearchChipPicker({container, hiddenId, searchUrl, resultKey, maxItems, currentValues}){
+  const values = currentValues ? currentValues.split(',').map(v=>v.trim()).filter(Boolean) : [];
+  const hidden = document.createElement('input');
+  hidden.type='hidden'; hidden.id=hiddenId; hidden.value=values.join(',');
+  container.appendChild(hidden);
+
+  const chipsEl = document.createElement('div');
+  chipsEl.className='chip-picker-chips';
+  container.appendChild(chipsEl);
+
+  const searchInput = document.createElement('input');
+  searchInput.type='text'; searchInput.className='line-input';
+  searchInput.style.cssText='font-size:.85rem;margin:6px 0 0 0;text-transform:none';
+  searchInput.placeholder='Search…';
+  container.appendChild(searchInput);
+
+  const resultsEl = document.createElement('div');
+  resultsEl.className='chip-picker-results';
+  container.appendChild(resultsEl);
+
+  function renderChips(){
+    chipsEl.innerHTML='';
+    values.forEach((v,i)=>{
+      const chip = document.createElement('span');
+      chip.className='team-chip selected';
+      chip.style.cssText='display:inline-flex;align-items:center;gap:4px;margin:2px;padding:4px 8px';
+      chip.innerHTML=`${v} <span style="cursor:pointer;opacity:.6" data-idx="${i}">✕</span>`;
+      chip.querySelector('span').onclick=(e)=>{ e.stopPropagation(); values.splice(i,1); sync(); };
+      chipsEl.appendChild(chip);
+    });
+  }
+
+  function sync(){
+    hidden.value = values.join(',');
+    renderChips();
+  }
+
+  let debounce=null;
+  searchInput.oninput=()=>{
+    clearTimeout(debounce);
+    const q = searchInput.value.trim();
+    if(q.length<1){ resultsEl.innerHTML=''; return; }
+    debounce=setTimeout(async()=>{
+      try{
+        const res = await fetch(`${searchUrl}?q=${encodeURIComponent(q)}`);
+        const data = await res.json();
+        const items = data[resultKey]||[];
+        resultsEl.innerHTML='';
+        items.forEach(item=>{
+          const already = values.includes(item.value);
+          const el = document.createElement('div');
+          el.className='chip-picker-result'+(already?' selected':'');
+          el.textContent=item.label;
+          el.onclick=()=>{
+            if(already) return;
+            if(maxItems && values.length>=maxItems) values.shift();
+            values.push(item.value);
+            sync();
+            el.classList.add('selected');
+          };
+          resultsEl.appendChild(el);
+        });
+      }catch(e){ resultsEl.innerHTML='<span style="color:var(--red);font-size:.8rem">Search failed</span>'; }
+    },300);
+  };
+
+  renderChips();
 }
 
 // ============================================================

--- a/server/static/styles.css
+++ b/server/static/styles.css
@@ -217,6 +217,13 @@ input:checked+.slider:before{transform:translateX(20px)}
 .team-chip:hover{border-color:var(--accent)}
 .team-chip.selected{background:var(--accent);color:#111;border-color:var(--accent)}
 
+/* ── CHIP PICKER ── */
+.chip-picker-chips{display:flex;flex-wrap:wrap;gap:4px;min-height:24px}
+.chip-picker-results{max-height:180px;overflow-y:auto;margin-top:4px}
+.chip-picker-result{padding:6px 10px;font-size:.82rem;cursor:pointer;border-radius:4px;transition:.12s}
+.chip-picker-result:hover{background:#2a2a2a}
+.chip-picker-result.selected{opacity:.4;pointer-events:none}
+
 /* ── MOBILE ── */
 @media(max-width:600px){
   body{padding:56px 10px 56px 10px}


### PR DESCRIPTION
## Summary
- Reusable `createSearchChipPicker()` component for searchable, chip-based selection
- New server endpoints: `/timezones`, `/stocks_search`, `/crypto_search`
- Updated settings UI for: weather, world clock, stocks, crypto, countdown, livestream
- Replaces plain text inputs with search + select + chip display

Closes #4

## Test plan
- [ ] World Clock: search timezones, select up to 3, save, verify persisted
- [ ] Stocks: search tickers (e.g. "MSFT"), select, verify chip and save
- [ ] Crypto: search coins (e.g. "bitcoin"), verify Bitcoin (BTC) appears first
- [ ] Weather/Countdown/Livestream: verify timezone picker works (single select)

🤖 Generated with [Claude Code](https://claude.com/claude-code)