### PR TITLE
Add app playlists tab for sequencing apps

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -1347,6 +1347,9 @@ loop_delay  = 5
 stop_event  = threading.Event()
 last_sent_page = None
 active_app  = None
+active_app_playlist = None
+app_playlist_loop = True
+app_playlist_name = None
 
 last_fetches = {
     'weather': 0, 'metro': 0, 'sports': 0, 'stocks': 0,
@@ -1360,8 +1363,238 @@ app_caches = {
 }
 
 
+def _run_app_playlist():
+    """Execute one pass through the app playlist entries."""
+    global active_app_playlist, active_app, last_sent_page, last_fetches, app_caches
+
+    entries = active_app_playlist
+    if not entries:
+        active_app_playlist = None
+        return
+
+    while True:
+        for entry in entries:
+            if stop_event.is_set():
+                stop_event.clear()
+                return
+
+            etype = entry.get('type', 'app')
+            duration = float(entry.get('duration', 30))
+
+            if etype == 'compose':
+                # Send composed text to display
+                text = entry.get('text', '')
+                style = entry.get('style', 'ltr')
+                speed = int(entry.get('speed', 15))
+                order = get_animation_order(style)
+                max_dist = send_to_display(text, order, step_delay_ms=speed)
+                last_sent_page = text
+                # Wait for rotation + duration
+                rotation_time = max_dist * (4.0 / 64.0)
+                for _ in range(int(rotation_time * 10)):
+                    if stop_event.is_set():
+                        stop_event.clear()
+                        return
+                    time.sleep(0.1)
+                for _ in range(int(duration * 10)):
+                    if stop_event.is_set():
+                        stop_event.clear()
+                        return
+                    time.sleep(0.1)
+
+            elif etype == 'app':
+                app_key = entry.get('app', '')
+                if not app_key:
+                    continue
+                # Temporarily set active_app so existing fetch logic works
+                old_app = active_app
+                active_app = app_key
+                last_fetches = {k: 0 for k in last_fetches}
+                deadline = time.time() + duration
+
+                while time.time() < deadline:
+                    if stop_event.is_set():
+                        active_app = None
+                        stop_event.clear()
+                        return
+
+                    display_pages = _get_pages_for_app(app_key)
+                    if not display_pages:
+                        time.sleep(1)
+                        continue
+
+                    is_anim = app_key.startswith('anim_') or \
+                              (app_key in _plugin_registry and _plugin_registry[app_key].get('animation'))
+
+                    # Determine per-page delay
+                    if is_anim:
+                        eff_delay = max(0.1, float(settings.get('anim_speed', '0.4')))
+                    elif app_key in _plugin_registry:
+                        eff_delay = float(_plugin_registry[app_key].get('loop_delay', 5))
+                    elif app_key.startswith('plugin_'):
+                        pid = app_key[7:]
+                        eff_delay = float(_plugin_registry.get(pid, {}).get('loop_delay', 5))
+                    elif app_key in ('countdown', 'world_clock'):
+                        eff_delay = 1
+                    elif app_key == 'stocks':
+                        eff_delay = 10
+                    else:
+                        eff_delay = 5
+
+                    active_order = None
+                    if is_anim:
+                        active_order = get_animation_order(settings.get('anim_style', 'ltr'))
+
+                    for page in display_pages:
+                        if stop_event.is_set() or time.time() >= deadline:
+                            break
+                        page_text = page.get('text', '') if isinstance(page, dict) else page
+                        page_order = get_animation_order(page.get('style', 'ltr')) if isinstance(page, dict) else active_order
+                        page_speed = int(page.get('speed', 15)) if isinstance(page, dict) else 15
+                        page_delay = float(page.get('delay', eff_delay)) if isinstance(page, dict) else eff_delay
+
+                        if is_anim or page_text != last_sent_page:
+                            max_dist = send_to_display(page_text, page_order, raw=is_anim, step_delay_ms=page_speed)
+                            last_sent_page = page_text
+
+                        rotation_time = max_dist * (4.0 / 64.0)
+                        for _ in range(int(rotation_time * 10)):
+                            if stop_event.is_set() or time.time() >= deadline: break
+                            time.sleep(0.1)
+                        for _ in range(int(page_delay * 10)):
+                            if stop_event.is_set() or time.time() >= deadline: break
+                            time.sleep(0.1)
+
+                active_app = None
+
+        # After all entries
+        if not app_playlist_loop:
+            active_app_playlist = None
+            return
+        # Otherwise loop continues
+
+
+def _get_pages_for_app(app_key):
+    """Fetch display pages for an app (reuses existing logic)."""
+    now = time.time()
+
+    if app_key in _plugin_registry:
+        return get_plugin_pages(app_key)
+
+    elif app_key == 'time':
+        tz = pytz.timezone(settings.get('timezone', 'US/Eastern'))
+        return [format_lines("", datetime.now(tz).strftime("%I:%M %p").lstrip("0"), "")]
+
+    elif app_key == 'date':
+        tz = pytz.timezone(settings.get('timezone', 'US/Eastern'))
+        dt = datetime.now(tz)
+        return [format_lines(dt.strftime("%I:%M %p").lstrip("0"), dt.strftime("%B %d").upper(), dt.strftime("%A").upper())]
+
+    elif app_key == 'countdown':
+        return fetch_countdown()
+
+    elif app_key == 'world_clock':
+        return fetch_world_clock()
+
+    elif app_key == 'weather':
+        if now - last_fetches['weather'] > 300:
+            app_caches['weather'] = fetch_weather_data()
+            last_fetches['weather'] = now
+        w = app_caches['weather']
+        if not w:
+            return [format_lines("NO WEATHER DATA", "", "CHECK API KEY")]
+        c = get_cols()
+        now_t = datetime.now(pytz.timezone(settings.get('timezone', 'US/Eastern'))).strftime("%I:%M%p").lstrip("0")
+        mcl = c - 1 - len(now_t)
+        l1 = f"{w['city'][:mcl]} {now_t}".center(c)
+        pfx = f"{w['temp']}F ({w['feels']}F) "
+        l2 = (pfx + w['desc'][:c-len(pfx)]).center(c)
+        l3 = f"H:{w['high']}F L:{w['low']}F".center(c)
+        return [format_lines(l1, l2, l3)]
+
+    elif app_key == 'dashboard':
+        tz = pytz.timezone(settings.get('timezone', 'US/Eastern'))
+        dt = datetime.now(tz)
+        time_page = format_lines(dt.strftime("%A").upper(), dt.strftime("%b %d %Y").upper(), dt.strftime("%I:%M %p").upper())
+        if now - last_fetches['weather'] > 300:
+            app_caches['weather'] = fetch_weather_data()
+            last_fetches['weather'] = now
+        w = app_caches['weather']
+        if not w:
+            wp = format_lines("NO WEATHER DATA", "", "CHECK API KEY")
+        else:
+            c = get_cols()
+            now_t = dt.strftime("%I:%M%p").lstrip("0")
+            mcl = c - 1 - len(now_t)
+            l1 = f"{w['city'][:mcl]} {now_t}".center(c)
+            pfx = f"{w['temp']}F ({w['feels']}F) "
+            l2 = (pfx + w['desc'][:c-len(pfx)]).center(c)
+            l3 = f"H:{w['high']}F L:{w['low']}F".center(c)
+            wp = format_lines(l1, l2, l3)
+        return [time_page, wp]
+
+    elif app_key == 'youtube':
+        if now - last_fetches['youtube'] > 30:
+            app_caches['youtube'] = fetch_youtube_data()
+            last_fetches['youtube'] = now
+        yt = app_caches['youtube']
+        return ([format_lines("YOUTUBE", yt['name'][:get_cols()], f"{yt['subs']} SUBS")]
+                if yt else [format_lines("YOUTUBE", "FETCH ERROR", "CHECK API")])
+
+    elif app_key == 'yt_comments':
+        if now - last_fetches['yt_comments'] > 60:
+            app_caches['yt_comments'] = fetch_youtube_comments()
+            last_fetches['yt_comments'] = now
+        return app_caches.get('yt_comments', [format_lines("LOADING", "COMMENTS...", "")])
+
+    elif app_key == 'metro':
+        if now - last_fetches['metro'] > 30:
+            app_caches['metro'] = fetch_metro()
+            last_fetches['metro'] = now
+        return app_caches['metro']
+
+    elif app_key == 'stocks':
+        if now - last_fetches['stocks'] > 60:
+            app_caches['stocks'] = fetch_stocks()
+            last_fetches['stocks'] = now
+        return app_caches['stocks']
+
+    elif app_key == 'sports':
+        if now - last_fetches['sports'] > 60:
+            app_caches['sports'] = fetch_sports()
+            last_fetches['sports'] = now
+        return app_caches['sports']
+
+    elif app_key == 'crypto':
+        if now - last_fetches['crypto'] > 60:
+            app_caches['crypto'] = fetch_crypto()
+            last_fetches['crypto'] = now
+        return app_caches.get('crypto', [format_lines("LOADING", "CRYPTO...", "")])
+
+    elif app_key == 'iss':
+        if now - last_fetches['iss'] > 5:
+            app_caches['iss'] = fetch_iss()
+            last_fetches['iss'] = now
+        return app_caches.get('iss', [format_lines("LOADING", "ISS...", "")])
+
+    elif app_key == 'livestream':
+        if now - last_fetches.get('youtube', 0) > 60:
+            app_caches['youtube'] = fetch_youtube_data()
+            last_fetches['youtube'] = now
+        if now - last_fetches.get('livestream_viewers', 0) > 30:
+            app_caches['livestream_viewers'] = fetch_youtube_viewers()
+            last_fetches['livestream_viewers'] = now
+        return build_livestream_pages()
+
+    elif app_key and app_key.startswith('plugin_'):
+        return get_plugin_pages(app_key[7:])
+
+    return []
+
+
 def playlist_loop():
     global current_playlist, loop_delay, last_sent_page, active_app, last_fetches, app_caches
+    global active_app_playlist, app_playlist_loop
 
     while True:
         now = time.time()
@@ -1373,6 +1606,11 @@ def playlist_loop():
             run_demo()
             if stop_event.is_set():
                 stop_event.clear()
+            continue
+
+        # ── App playlist mode ─────────────────────────────
+        if active_app_playlist is not None:
+            _run_app_playlist()
             continue
 
         # ── Static / real-time apps ──────────────────────────
@@ -1604,6 +1842,8 @@ def index():
 @app.route('/current_state')
 def current_state():
     return jsonify(is_homed=is_homed, state=current_display_string, active_app=active_app,
+                   active_app_playlist=active_app_playlist is not None,
+                   app_playlist_name=app_playlist_name,
                    rows=get_rows(), cols=get_cols(), sim_mode=sim_mode, hardware_connected=ser is not None)
 
 @app.route('/grid_config')
@@ -1757,19 +1997,21 @@ def toggle_autohome():
 
 @app.route('/update_playlist', methods=['POST'])
 def update_playlist():
-    global current_playlist, loop_delay, last_sent_page, active_app
+    global current_playlist, loop_delay, last_sent_page, active_app, active_app_playlist
     data             = request.json
     current_playlist = data.get('pages', [])
     loop_delay       = data.get('delay', 5)
     last_sent_page   = None
     active_app       = None
+    active_app_playlist = None
     stop_event.set()
     mqtt_publish_state()
     return jsonify(status="success")
 
 @app.route('/run_app', methods=['POST'])
 def run_app():
-    global active_app, last_fetches, loop_delay
+    global active_app, last_fetches, loop_delay, active_app_playlist
+    active_app_playlist = None
     active_app   = request.json.get('app')
     last_fetches = {k: 0 for k in last_fetches}
 
@@ -1797,8 +2039,9 @@ def run_app():
 
 @app.route('/stop_app', methods=['POST'])
 def stop_app():
-    global active_app
+    global active_app, active_app_playlist
     active_app = None
+    active_app_playlist = None
     stop_event.set()
     mqtt_publish_state()
     return jsonify(status="stopped")
@@ -1980,6 +2223,51 @@ def delete_playlist(name):
     if name in plists:
         del plists[name]
         settings['saved_playlists'] = plists
+        save_settings(settings)
+    return jsonify(status="deleted")
+
+
+# ============================================================
+#  APP PLAYLISTS
+# ============================================================
+
+@app.route('/run_app_playlist', methods=['POST'])
+def run_app_playlist():
+    global active_app_playlist, app_playlist_loop, active_app, current_playlist, last_sent_page, app_playlist_name
+    data = request.json
+    active_app_playlist = data.get('entries', [])
+    app_playlist_loop = data.get('loop', True)
+    app_playlist_name = data.get('name', None)
+    active_app = None
+    current_playlist = []
+    last_sent_page = None
+    stop_event.set()
+    mqtt_publish_state()
+    return jsonify(status="App playlist started")
+
+@app.route('/app_playlists', methods=['GET', 'POST'])
+def app_playlists():
+    if request.method == 'GET':
+        return jsonify(settings.get('saved_app_playlists', {}))
+    data = request.json
+    name = (data.get('name') or '').strip()
+    if not name:
+        return jsonify(status="error", message="Name required"), 400
+    if 'saved_app_playlists' not in settings:
+        settings['saved_app_playlists'] = {}
+    settings['saved_app_playlists'][name] = {
+        'entries': data.get('entries', []),
+        'loop': data.get('loop', True),
+    }
+    save_settings(settings)
+    return jsonify(status="saved", name=name)
+
+@app.route('/app_playlists/<path:name>', methods=['DELETE'])
+def delete_app_playlist(name):
+    plists = settings.get('saved_app_playlists', {})
+    if name in plists:
+        del plists[name]
+        settings['saved_app_playlists'] = plists
         save_settings(settings)
     return jsonify(status="deleted")
 

--- a/server/static/app.js
+++ b/server/static/app.js
@@ -307,13 +307,15 @@ setInterval(()=>{
 
     // Active app banner (single)
     const app = data.active_app;
+    const playlistRunning = data.active_app_playlist;
+    const playlistName = data.app_playlist_name;
     currentActiveApp = app;
-    const appLabel = app ? (APP_LIST.find(a=>a.key===app)||{name:app}).name : null;
+    const appLabel = playlistRunning ? (playlistName ? `Playlist: ${playlistName}` : 'Playlist') : (app ? (APP_LIST.find(a=>a.key===app)||{name:app}).name : null);
     const banner = document.getElementById('control-banner');
     const nameEl = document.getElementById('control-app-name');
     if(banner){
-      banner.classList.toggle('visible', !!app);
-      if(app && nameEl) nameEl.textContent = appLabel;
+      banner.classList.toggle('visible', !!(app || playlistRunning));
+      if((app || playlistRunning) && nameEl) nameEl.textContent = appLabel;
     }
 
     // Running highlight on app cards
@@ -332,6 +334,7 @@ function switchTab(name){
   document.getElementById('tab-'+name).classList.add('active');
   document.getElementById('page-'+name).classList.add('active');
   if(name==='apps') buildAppsGrid();
+  if(name==='playlists'){ loadSavedAppPlaylists(); if(typeof lucide!=='undefined') lucide.createIcons(); }
 }
 
 // ── Hamburger ──
@@ -1850,7 +1853,190 @@ function saveSportsFollow(league){
     body:JSON.stringify({league, teams})});
 }
 
+// ============================================================
+//  APP PLAYLISTS
+// ============================================================
+let appPlaylistEntries = [];
+
+function renderAppPlaylistEntries(){
+  const el = document.getElementById('appPlaylistEntries');
+  if(!appPlaylistEntries.length){
+    el.innerHTML='<div style="color:#666;font-style:italic;font-size:.85rem">No entries yet. Add apps or messages below.</div>';
+    return;
+  }
+  el.innerHTML='';
+  appPlaylistEntries.forEach((entry,i)=>{
+    const row = document.createElement('div');
+    row.className='ap-entry';
+    const label = entry.type==='app'
+      ? `${(APP_LIST.find(a=>a.key===entry.app)||{icon:'📦'}).icon} ${(APP_LIST.find(a=>a.key===entry.app)||{name:entry.app}).name}`
+      : null;
+    if(entry.type==='compose'){
+      row.innerHTML=`
+        <span style="font-size:.75rem;color:#888;margin-right:2px">📝</span>
+        <input type="text" class="ap-entry-text" value="${(entry.text||'').replace(/"/g,'&quot;')}" placeholder="Type message…"
+          oninput="appPlaylistEntries[${i}].text=this.value" data-idx="${i}">
+        <input type="number" class="ap-entry-dur" value="${entry.duration||10}" min="1" max="600" step="1"
+          onchange="appPlaylistEntries[${i}].duration=parseInt(this.value)||10" title="Duration (seconds)">
+        <span style="font-size:.75rem;color:#888">s</span>
+        <button class="ap-entry-btn" onclick="moveAppEntry(${i},-1)" title="Move up">↑</button>
+        <button class="ap-entry-btn" onclick="moveAppEntry(${i},1)" title="Move down">↓</button>
+        <button class="ap-entry-btn" onclick="removeAppEntry(${i})" title="Remove">✕</button>`;
+    } else {
+      row.innerHTML=`
+        <span class="ap-entry-label">${label}</span>
+        <input type="number" class="ap-entry-dur" value="${entry.duration||30}" min="5" max="600" step="5"
+          onchange="appPlaylistEntries[${i}].duration=parseInt(this.value)||30" title="Duration (seconds)">
+        <span style="font-size:.75rem;color:#888">s</span>
+        <button class="ap-entry-btn" onclick="moveAppEntry(${i},-1)" title="Move up">↑</button>
+        <button class="ap-entry-btn" onclick="moveAppEntry(${i},1)" title="Move down">↓</button>
+        <button class="ap-entry-btn" onclick="removeAppEntry(${i})" title="Remove">✕</button>`;
+    }
+    el.appendChild(row);
+  });
+}
+
+function addAppPlaylistEntry(type){
+  if(type==='app'){
+    // Show a picker
+    const modal = document.createElement('div');
+    modal.className='modal-overlay';
+    modal.style.display='flex';
+    modal.innerHTML=`
+      <div class="modal-content" style="max-width:400px">
+        <h3 style="color:var(--accent);margin-bottom:12px">Add App to Playlist</h3>
+        <select id="apPickerSelect" style="width:100%;background:#111;color:#fff;border:1px solid #555;padding:8px;border-radius:4px;font-size:.9rem;margin-bottom:12px">
+          ${APP_LIST.map(a=>`<option value="${a.key}">${a.icon} ${a.name}</option>`).join('')}
+        </select>
+        <label style="font-size:.85rem;color:#aaa;display:flex;align-items:center;gap:6px;margin-bottom:14px">
+          Duration <input type="number" id="apPickerDur" value="30" min="5" max="600" step="5"
+            style="width:70px;padding:5px;background:#111;color:#fff;border:1px solid #555;border-radius:4px;text-align:center"> seconds
+        </label>
+        <div style="display:flex;gap:8px">
+          <button class="btn btn-success" style="flex:1" onclick="confirmAddApp(this)">Add</button>
+          <button class="btn" style="background:#333;color:#aaa;border:1px solid #555" onclick="this.closest('.modal-overlay').remove()">Cancel</button>
+        </div>
+      </div>`;
+    document.body.appendChild(modal);
+  } else {
+    // Compose entry — add empty and focus
+    appPlaylistEntries.push({type:'compose', text:'', duration:10, style:'ltr', speed:15});
+    renderAppPlaylistEntries();
+    const inputs = document.querySelectorAll('.ap-entry-text');
+    if(inputs.length) inputs[inputs.length-1].focus();
+  }
+}
+
+function confirmAddApp(btn){
+  const modal = btn.closest('.modal-overlay');
+  const app = document.getElementById('apPickerSelect').value;
+  const dur = parseInt(document.getElementById('apPickerDur').value)||30;
+  appPlaylistEntries.push({type:'app', app, duration:dur});
+  modal.remove();
+  renderAppPlaylistEntries();
+}
+
+function moveAppEntry(i, dir){
+  const j = i+dir;
+  if(j<0||j>=appPlaylistEntries.length) return;
+  [appPlaylistEntries[i], appPlaylistEntries[j]] = [appPlaylistEntries[j], appPlaylistEntries[i]];
+  renderAppPlaylistEntries();
+}
+
+function removeAppEntry(i){
+  appPlaylistEntries.splice(i,1);
+  renderAppPlaylistEntries();
+}
+
+function runAppPlaylist(){
+  if(!appPlaylistEntries.length){ showToast('Add entries first','warn'); return; }
+  const loop = document.getElementById('appPlaylistLoop').checked;
+  fetch('/run_app_playlist',{method:'POST',headers:{'Content-Type':'application/json'},
+    body:JSON.stringify({entries:appPlaylistEntries, loop})});
+  showToast('▶ Playlist started');
+}
+
+function openSaveAppPlaylist(){
+  if(!appPlaylistEntries.length){ showToast('Add entries first','warn'); return; }
+  const modal = document.createElement('div');
+  modal.className='modal-overlay';
+  modal.style.display='flex';
+  modal.innerHTML=`
+    <div class="modal-content" style="max-width:360px">
+      <h3 style="color:var(--accent);margin-bottom:12px">Save Playlist</h3>
+      <input type="text" id="saveAppPlaylistName" placeholder="Playlist name…" class="line-input" style="font-size:.9rem;margin-bottom:14px;text-transform:none">
+      <div style="display:flex;gap:8px">
+        <button class="btn btn-success" style="flex:1" onclick="saveAppPlaylist();this.closest('.modal-overlay').remove()">Save</button>
+        <button class="btn" style="background:#333;color:#aaa;border:1px solid #555" onclick="this.closest('.modal-overlay').remove()">Cancel</button>
+      </div>
+    </div>`;
+  document.body.appendChild(modal);
+  setTimeout(()=>document.getElementById('saveAppPlaylistName').focus(),50);
+}
+
+function saveAppPlaylist(){
+  const name = document.getElementById('saveAppPlaylistName').value.trim();
+  if(!name){ showToast('Enter a name','warn'); return; }
+  if(!appPlaylistEntries.length){ showToast('Add entries first','warn'); return; }
+  const loop = document.getElementById('appPlaylistLoop').checked;
+  fetch('/app_playlists',{method:'POST',headers:{'Content-Type':'application/json'},
+    body:JSON.stringify({name, entries:appPlaylistEntries, loop})})
+  .then(()=>{ showToast('Playlist saved'); loadSavedAppPlaylists(); });
+}
+
+function loadSavedAppPlaylists(){
+  fetch('/app_playlists').then(r=>r.json()).then(data=>{
+    const el = document.getElementById('savedAppPlaylistList');
+    const names = Object.keys(data);
+    if(!names.length){ el.innerHTML='<div style="color:#666;font-style:italic;font-size:.85rem">No saved playlists yet.</div>'; return; }
+    el.innerHTML='';
+    names.forEach(name=>{
+      const pl = data[name];
+      const count = (pl.entries||[]).length;
+      const row = document.createElement('div');
+      row.style.cssText='display:flex;align-items:center;gap:8px;padding:8px 0;border-bottom:1px solid #333';
+      row.innerHTML=`
+        <span style="flex:1;font-size:.9rem">${name} <span style="color:#888;font-size:.75rem">(${count} items${pl.loop?' · loop':''})</span></span>
+        <button class="btn btn-sm" style="background:#333;color:#ccc;border:1px solid #555" onclick="loadAppPlaylist('${name.replace(/'/g,"\\'")}')">Load</button>
+        <button class="btn btn-success btn-sm" onclick="runSavedAppPlaylist('${name.replace(/'/g,"\\'")}')">▶ Run</button>
+        <button class="btn-del btn-sm" style="padding:4px 8px;border-radius:4px" onclick="deleteAppPlaylist('${name.replace(/'/g,"\\'")}')">✕</button>`;
+      el.appendChild(row);
+    });
+  });
+}
+
+function loadAppPlaylist(name){
+  fetch('/app_playlists').then(r=>r.json()).then(data=>{
+    const pl = data[name];
+    if(!pl) return;
+    appPlaylistEntries = pl.entries||[];
+    document.getElementById('appPlaylistLoop').checked = pl.loop!==false;
+    renderAppPlaylistEntries();
+    showToast(`Loaded "${name}"`);
+  });
+}
+
+function runSavedAppPlaylist(name){
+  fetch('/app_playlists').then(r=>r.json()).then(data=>{
+    const pl = data[name];
+    if(!pl) return;
+    appPlaylistEntries = pl.entries||[];
+    document.getElementById('appPlaylistLoop').checked = pl.loop!==false;
+    renderAppPlaylistEntries();
+    fetch('/run_app_playlist',{method:'POST',headers:{'Content-Type':'application/json'},
+      body:JSON.stringify({entries:pl.entries, loop:pl.loop!==false, name})});
+    showToast(`▶ "${name}" started`);
+  });
+}
+
+function deleteAppPlaylist(name){
+  if(!confirm(`Delete "${name}"?`)) return;
+  fetch(`/app_playlists/${encodeURIComponent(name)}`,{method:'DELETE'})
+  .then(()=>{ showToast(`Deleted "${name}"`,'warn'); loadSavedAppPlaylists(); });
+}
+
 buildAppsGrid();
 loadSavedPlaylists();
+loadSavedAppPlaylists();
 updatePreview();
 if(typeof lucide!=='undefined') lucide.createIcons();

--- a/server/static/styles.css
+++ b/server/static/styles.css
@@ -96,11 +96,12 @@ h3{margin-top:0;color:var(--text)}
 .btn{padding:12px 20px;border-radius:6px;border:none;font-weight:bold;cursor:pointer;transition:.2s;font-size:1rem}
 .btn:active{transform:scale(.98)}
 .btn-primary{background:var(--accent);color:#fff;width:100%;margin-top:16px;padding:16px;font-size:1.1rem}
+.btn-sm.btn-primary{width:auto;margin-top:0;padding:7px 12px;font-size:.85rem}
 .btn-success{background:var(--green);color:#fff}
 .btn-warning{background:var(--orange);color:#fff}
 .btn-secondary{background:#444;color:#fff}
 .btn-del{background:var(--red);color:#fff;border:none;padding:6px 12px;border-radius:4px;cursor:pointer;font-weight:bold}
-.btn-sm{padding:7px 12px;font-size:.85rem}
+.btn-sm{padding:7px 12px;font-size:.85rem;display:inline-flex;align-items:center;gap:4px}
 
 /* ── PLAYLIST ── */
 .playlist-area{margin-top:12px;background:var(--panel);padding:14px;border-radius:8px;border:1px solid var(--border)}
@@ -223,6 +224,17 @@ input:checked+.slider:before{transform:translateX(20px)}
 .chip-picker-result{padding:6px 10px;font-size:.82rem;cursor:pointer;border-radius:4px;transition:.12s}
 .chip-picker-result:hover{background:#2a2a2a}
 .chip-picker-result.selected{opacity:.4;pointer-events:none}
+
+/* ── APP PLAYLIST ENTRIES ── */
+.ap-entry{display:flex;align-items:center;gap:8px;padding:10px 12px;background:#222;border:1px solid var(--border);border-left:4px solid var(--accent);border-radius:6px;margin-bottom:8px;transition:.15s}
+.ap-entry:hover{border-color:var(--accent);background:#252525}
+.ap-entry-label{flex:1;font-size:.88rem;font-weight:600;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;font-family:monospace}
+.ap-entry-dur{width:50px;padding:5px;background:#111;color:#fff;border:1px solid #555;border-radius:4px;text-align:center;font-size:.82rem;font-family:monospace}
+.ap-entry-btn{background:#2a2a2a;border:1px solid #555;color:#888;border-radius:4px;padding:4px 8px;cursor:pointer;font-size:.8rem;transition:.15s}
+.ap-entry-btn:hover{border-color:var(--accent);color:var(--accent);background:#333}
+.ap-entry-text{flex:1;background:#111;color:var(--green);border:1px solid #555;border-radius:4px;padding:6px 10px;font-size:.85rem;font-family:'Courier New',monospace;text-transform:uppercase}
+.ap-entry-text:focus{border-color:var(--accent);outline:none}
+.ap-controls{display:flex;flex-wrap:wrap;gap:10px;margin-top:14px;align-items:center;padding:12px 14px;background:var(--panel);border:1px solid var(--border);border-radius:8px}
 
 /* ── MOBILE ── */
 @media(max-width:600px){

--- a/server/templates/index.html
+++ b/server/templates/index.html
@@ -113,6 +113,37 @@
     <button class="btn btn-secondary" style="width:100%;margin-top:20px" onclick="openAppLibrary()">+ Install App</button>
   </div>
 
+  <!-- ══════════ PLAYLISTS PAGE ══════════ -->
+  <div id="page-playlists" class="page">
+    <h3 style="margin-bottom:12px">App Playlists</h3>
+
+    <div id="appPlaylistEntries" class="playlist-area" style="min-height:60px">
+      <div style="color:#666;font-style:italic;font-size:.85rem">No entries yet. Add apps or messages below.</div>
+    </div>
+
+    <div style="display:flex;gap:8px;margin-top:12px;flex-wrap:wrap">
+      <button class="btn btn-success btn-sm" onclick="addAppPlaylistEntry('app')">+ Add App</button>
+      <button class="btn btn-secondary btn-sm" onclick="addAppPlaylistEntry('compose')">+ Add Message</button>
+    </div>
+
+    <div class="ap-controls">
+      <label style="cursor:pointer;font-size:.85rem;display:flex;align-items:center;gap:6px">
+        <input type="checkbox" id="appPlaylistLoop" checked> Loop
+      </label>
+      <div style="margin-left:auto;display:flex;gap:8px;align-items:center">
+        <button class="btn btn-success btn-sm" onclick="openSaveAppPlaylist()"><i data-lucide="save" style="width:14px;height:14px"></i> Save…</button>
+        <button class="btn btn-primary btn-sm" onclick="runAppPlaylist()"><i data-lucide="play" style="width:14px;height:14px"></i> Run</button>
+        <button class="btn btn-secondary btn-sm" onclick="stopApp()"><i data-lucide="square" style="width:14px;height:14px"></i> Stop</button>
+      </div>
+    </div>
+
+    <!-- Saved App Playlists -->
+    <div class="playlist-area" style="margin-top:18px">
+      <h3 style="margin:0 0 10px 0;font-size:.95rem">📂 Saved Playlists</h3>
+      <div id="savedAppPlaylistList"><div style="color:#666;font-style:italic;font-size:.85rem">No saved playlists yet.</div></div>
+    </div>
+  </div>
+
   <!-- ══════════ LIBRARY PAGE ══════════ -->
   <div id="page-library" class="page">
     <button class="hamburger-back" onclick="closeMenuPage()"><i data-lucide="arrow-left" style="width:14px;height:14px"></i> Back</button>
@@ -219,6 +250,7 @@
 <div class="bottom-tabs" id="bottomTabs">
   <button class="bottom-tab active" id="tab-apps" onclick="switchTab('apps')"><i data-lucide="layout-grid" style="width:16px;height:16px"></i> Apps</button>
   <button class="bottom-tab" id="tab-control" onclick="switchTab('control')"><i data-lucide="pen-line" style="width:16px;height:16px"></i> Compose</button>
+  <button class="bottom-tab" id="tab-playlists" onclick="switchTab('playlists')"><i data-lucide="list-music" style="width:16px;height:16px"></i> Playlists</button>
 </div>
 
 <!-- HAMBURGER OVERLAY -->


### PR DESCRIPTION
## Summary
- New **Playlists** tab for building sequences of apps and composed messages
- Per-entry duration control, loop toggle, save/load/delete
- Backend playlist loop cycles through entries, running each app for its configured duration
- Active playlist name shown in the running banner
- Lucide icons on action buttons, polished entry row styling

Closes #6

## Test plan
- [ ] Add apps and messages to a playlist, verify reorder/remove works
- [ ] Run playlist, verify each app displays for its duration then transitions
- [ ] Toggle loop on/off, verify behavior
- [ ] Save playlist, reload page, verify persistence
- [ ] Run saved playlist, verify banner shows "Playlist: <name>"
- [ ] Stop via banner or Stop button
- [ ] Run a single app while playlist active — playlist stops

🤖 Generated with [Claude Code](https://claude.com/claude-code)