### PR TITLE
Sports improvements, settings cleanup, logo, delays

### DIFF
--- a/apps/chuck-norris/manifest.json
+++ b/apps/chuck-norris/manifest.json
@@ -8,5 +8,15 @@
   "version": "1.0",
   "refresh_interval": 300,
   "loop_delay": 10,
-  "settings": []
+  "settings": [
+    {
+      "key": "loop_delay",
+      "label": "Delay Between Pages (seconds)",
+      "type": "number",
+      "default": "10",
+      "min": "2",
+      "max": "30",
+      "step": "1"
+    }
+  ]
 }

--- a/apps/crypto/manifest.json
+++ b/apps/crypto/manifest.json
@@ -1,10 +1,21 @@
 {
   "id": "crypto",
   "name": "Crypto",
-  "icon": "\u20bf",
+  "icon": "₿",
   "description": "Coin prices",
   "type": "functional",
   "refresh_interval": 60,
   "loop_delay": 5,
+  "settings": [
+    {
+      "key": "loop_delay",
+      "label": "Delay Between Pages (seconds)",
+      "type": "number",
+      "default": "5",
+      "min": "2",
+      "max": "30",
+      "step": "1"
+    }
+  ],
   "category": "finance"
 }

--- a/apps/dad-jokes/manifest.json
+++ b/apps/dad-jokes/manifest.json
@@ -8,5 +8,15 @@
   "version": "1.0",
   "refresh_interval": 300,
   "loop_delay": 8,
-  "settings": []
+  "settings": [
+    {
+      "key": "loop_delay",
+      "label": "Delay Between Pages (seconds)",
+      "type": "number",
+      "default": "8",
+      "min": "2",
+      "max": "30",
+      "step": "1"
+    }
+  ]
 }

--- a/apps/dashboard/manifest.json
+++ b/apps/dashboard/manifest.json
@@ -1,11 +1,21 @@
 {
   "id": "dashboard",
   "name": "Dashboard",
-  "icon": "\ud83c\udfe0",
+  "icon": "🏠",
   "description": "Time + weather",
   "type": "functional",
   "refresh_interval": 60,
   "loop_delay": 5,
-  "settings": [],
+  "settings": [
+    {
+      "key": "loop_delay",
+      "label": "Delay Between Pages (seconds)",
+      "type": "number",
+      "default": "5",
+      "min": "2",
+      "max": "30",
+      "step": "1"
+    }
+  ],
   "category": "data"
 }

--- a/apps/fortune-cookie/manifest.json
+++ b/apps/fortune-cookie/manifest.json
@@ -8,5 +8,15 @@
   "version": "1.0",
   "refresh_interval": 300,
   "loop_delay": 8,
-  "settings": []
+  "settings": [
+    {
+      "key": "loop_delay",
+      "label": "Delay Between Pages (seconds)",
+      "type": "number",
+      "default": "8",
+      "min": "2",
+      "max": "30",
+      "step": "1"
+    }
+  ]
 }

--- a/apps/funny-one-liners/manifest.json
+++ b/apps/funny-one-liners/manifest.json
@@ -8,5 +8,15 @@
   "version": "1.0",
   "refresh_interval": 300,
   "loop_delay": 8,
-  "settings": []
+  "settings": [
+    {
+      "key": "loop_delay",
+      "label": "Delay Between Pages (seconds)",
+      "type": "number",
+      "default": "8",
+      "min": "2",
+      "max": "30",
+      "step": "1"
+    }
+  ]
 }

--- a/apps/good-morning/manifest.json
+++ b/apps/good-morning/manifest.json
@@ -8,5 +8,15 @@
   "version": "1.0",
   "refresh_interval": 300,
   "loop_delay": 8,
-  "settings": []
+  "settings": [
+    {
+      "key": "loop_delay",
+      "label": "Delay Between Pages (seconds)",
+      "type": "number",
+      "default": "8",
+      "min": "2",
+      "max": "30",
+      "step": "1"
+    }
+  ]
 }

--- a/apps/good-night/manifest.json
+++ b/apps/good-night/manifest.json
@@ -8,5 +8,15 @@
   "version": "1.0",
   "refresh_interval": 300,
   "loop_delay": 8,
-  "settings": []
+  "settings": [
+    {
+      "key": "loop_delay",
+      "label": "Delay Between Pages (seconds)",
+      "type": "number",
+      "default": "8",
+      "min": "2",
+      "max": "30",
+      "step": "1"
+    }
+  ]
 }

--- a/apps/harry-potter-quotes/manifest.json
+++ b/apps/harry-potter-quotes/manifest.json
@@ -8,5 +8,15 @@
   "version": "1.0",
   "refresh_interval": 300,
   "loop_delay": 10,
-  "settings": []
+  "settings": [
+    {
+      "key": "loop_delay",
+      "label": "Delay Between Pages (seconds)",
+      "type": "number",
+      "default": "10",
+      "min": "2",
+      "max": "30",
+      "step": "1"
+    }
+  ]
 }

--- a/apps/livestream/manifest.json
+++ b/apps/livestream/manifest.json
@@ -1,11 +1,21 @@
 {
   "id": "livestream",
   "name": "Livestream",
-  "icon": "\ud83d\udd34",
+  "icon": "🔴",
   "description": "Launch day rotate",
   "type": "functional",
   "refresh_interval": 30,
   "loop_delay": 5,
-  "settings": [],
+  "settings": [
+    {
+      "key": "loop_delay",
+      "label": "Delay Between Pages (seconds)",
+      "type": "number",
+      "default": "5",
+      "min": "2",
+      "max": "30",
+      "step": "1"
+    }
+  ],
   "category": "animation"
 }

--- a/apps/magic-8-ball/manifest.json
+++ b/apps/magic-8-ball/manifest.json
@@ -8,5 +8,15 @@
   "version": "1.0",
   "refresh_interval": 300,
   "loop_delay": 8,
-  "settings": []
+  "settings": [
+    {
+      "key": "loop_delay",
+      "label": "Delay Between Pages (seconds)",
+      "type": "number",
+      "default": "8",
+      "min": "2",
+      "max": "30",
+      "step": "1"
+    }
+  ]
 }

--- a/apps/metro/manifest.json
+++ b/apps/metro/manifest.json
@@ -1,10 +1,21 @@
 {
   "id": "metro",
   "name": "Metro",
-  "icon": "\ud83d\ude87",
+  "icon": "🚇",
   "description": "MBTA arrivals",
   "type": "functional",
   "refresh_interval": 30,
   "loop_delay": 5,
-  "category": "data"
+  "category": "data",
+  "settings": [
+    {
+      "key": "loop_delay",
+      "label": "Delay Between Pages (seconds)",
+      "type": "number",
+      "default": "5",
+      "min": "2",
+      "max": "30",
+      "step": "1"
+    }
+  ]
 }

--- a/apps/motivational-quotes/manifest.json
+++ b/apps/motivational-quotes/manifest.json
@@ -8,5 +8,15 @@
   "version": "1.0",
   "refresh_interval": 300,
   "loop_delay": 10,
-  "settings": []
+  "settings": [
+    {
+      "key": "loop_delay",
+      "label": "Delay Between Pages (seconds)",
+      "type": "number",
+      "default": "10",
+      "min": "2",
+      "max": "30",
+      "step": "1"
+    }
+  ]
 }

--- a/apps/national-today/manifest.json
+++ b/apps/national-today/manifest.json
@@ -8,5 +8,15 @@
   "version": "1.0",
   "refresh_interval": 3600,
   "loop_delay": 10,
-  "settings": []
+  "settings": [
+    {
+      "key": "loop_delay",
+      "label": "Delay Between Pages (seconds)",
+      "type": "number",
+      "default": "10",
+      "min": "2",
+      "max": "30",
+      "step": "1"
+    }
+  ]
 }

--- a/apps/news-headlines/manifest.json
+++ b/apps/news-headlines/manifest.json
@@ -9,6 +9,20 @@
   "refresh_interval": 600,
   "loop_delay": 8,
   "settings": [
-    {"key": "feed_url", "label": "RSS Feed URL", "type": "text", "default": "https://feeds.bbci.co.uk/news/rss.xml"}
+    {
+      "key": "feed_url",
+      "label": "RSS Feed URL",
+      "type": "text",
+      "default": "https://feeds.bbci.co.uk/news/rss.xml"
+    },
+    {
+      "key": "loop_delay",
+      "label": "Delay Between Pages (seconds)",
+      "type": "number",
+      "default": "8",
+      "min": "2",
+      "max": "30",
+      "step": "1"
+    }
   ]
 }

--- a/apps/office-quotes/manifest.json
+++ b/apps/office-quotes/manifest.json
@@ -8,5 +8,15 @@
   "version": "1.0",
   "refresh_interval": 300,
   "loop_delay": 10,
-  "settings": []
+  "settings": [
+    {
+      "key": "loop_delay",
+      "label": "Delay Between Pages (seconds)",
+      "type": "number",
+      "default": "10",
+      "min": "2",
+      "max": "30",
+      "step": "1"
+    }
+  ]
 }

--- a/apps/on-this-day/manifest.json
+++ b/apps/on-this-day/manifest.json
@@ -8,5 +8,15 @@
   "version": "1.0",
   "refresh_interval": 3600,
   "loop_delay": 10,
-  "settings": []
+  "settings": [
+    {
+      "key": "loop_delay",
+      "label": "Delay Between Pages (seconds)",
+      "type": "number",
+      "default": "10",
+      "min": "2",
+      "max": "30",
+      "step": "1"
+    }
+  ]
 }

--- a/apps/shower-thoughts/manifest.json
+++ b/apps/shower-thoughts/manifest.json
@@ -8,5 +8,15 @@
   "version": "1.0",
   "refresh_interval": 300,
   "loop_delay": 8,
-  "settings": []
+  "settings": [
+    {
+      "key": "loop_delay",
+      "label": "Delay Between Pages (seconds)",
+      "type": "number",
+      "default": "8",
+      "min": "2",
+      "max": "30",
+      "step": "1"
+    }
+  ]
 }

--- a/apps/sports/app.py
+++ b/apps/sports/app.py
@@ -26,7 +26,12 @@ def fetch(settings, format_lines, get_rows, get_cols):
     if settings.get('nhl_teams') and not settings.get('sports_nhl'):
         settings['sports_nhl'] = settings['nhl_teams']
         settings['nhl_teams'] = ''
-    pages = []
+
+    game_filter = settings.get('sports_filter', 'all')
+    show_league = settings.get('sports_show_league', 'yes') == 'yes'
+    compact = settings.get('sports_compact', 'no') == 'yes'
+
+    all_games = []
     for key, info in LEAGUES.items():
         teams_str = settings.get(f'sports_{key}', '').strip()
         if not teams_str:
@@ -34,19 +39,134 @@ def fetch(settings, format_lines, get_rows, get_cols):
         team_filter = [t.strip().upper() for t in teams_str.split(',') if t.strip()]
         show_all = '*' in team_filter
         try:
-            pages.extend(_fetch_league(key, info, team_filter, show_all, format_lines, get_cols, requests))
+            games = _fetch_league(key, info, team_filter, show_all, format_lines, get_cols, requests, game_filter)
+            all_games.extend(games)
         except Exception as e:
             logging.error(f"ESPN {key} error: {e}")
-    return pages or [format_lines("SPORTS", "NO GAMES", "CONFIGURED")]
 
-def _fetch_league(key, info, team_filter, show_all, format_lines, get_cols, requests):
-    url = f"https://site.api.espn.com/apis/site/v2/sports/{info['path']}/scoreboard"
+    if not all_games:
+        if any(settings.get(f'sports_{key}', '').strip() for key in LEAGUES):
+            filter_labels = {'all': 'ALL', 'live': 'LIVE', 'live+upcoming': 'LIVE/UPCOMING', 'live+final': 'LIVE/FINAL'}
+            return [format_lines("SPORTS", "NO GAMES", filter_labels.get(game_filter, 'FOUND'))]
+        return [format_lines("SPORTS", "NO TEAMS", "CONFIGURED")]
+
+    if not compact:
+        # Standard 1-game-per-page
+        if show_league:
+            return [g['page'] for g in all_games]
+        else:
+            cols = get_cols()
+            return [g['score_line'][:cols].center(cols) + (' ' * cols) + g['status'][:cols].center(cols) for g in all_games]
+
+    # Compact mode: 2 games per page
+    pages = []
+    for i in range(0, len(all_games), 2):
+        g1 = all_games[i]
+        cols = get_cols()
+        if i + 1 < len(all_games):
+            g2 = all_games[i + 1]
+            r1 = g1['score_line'][:cols].center(cols)
+            r2 = g2['score_line'][:cols].center(cols)
+            s1 = g1['status'][:7].ljust(7)
+            s2 = g2['status'][:7].rjust(cols - 7)
+            r3 = (s1 + s2)[:cols]
+            pages.append(r1 + r2 + r3)
+        else:
+            r1 = g1['score_line'][:cols].center(cols)
+            r2 = ' ' * cols
+            r3 = g1['status'][:cols].center(cols)
+            pages.append(r1 + r2 + r3)
+    return pages
+
+def _fetch_league(key, info, team_filter, show_all, format_lines, get_cols, requests, game_filter):
+    from datetime import datetime, timedelta
+    # Expand date range to catch recent finals and upcoming games
+    start = (datetime.now() - timedelta(days=7)).strftime('%Y%m%d')
+    end = (datetime.now() + timedelta(days=7)).strftime('%Y%m%d')
+    url = f"https://site.api.espn.com/apis/site/v2/sports/{info['path']}/scoreboard?dates={start}-{end}&limit=100"
     data = requests.get(url, timeout=8).json()
     events = data.get('events', [])
     if key == 'pga':
-        return _golf(events, info, format_lines)
+        return [{'page': p, 'score_line': '', 'status': ''} for p in _golf(events, info, format_lines)]
     if key == 'ufc':
-        return _mma(events, info, format_lines)
+        return [{'page': p, 'score_line': '', 'status': ''} for p in _mma(events, info, format_lines)]
+
+    games = _parse_events(events, info, team_filter, show_all, format_lines, get_cols, game_filter)
+
+    # If no games found from scoreboard, check team schedules for most recent game
+    if not games and not show_all:
+        seen_teams = set()
+        for abbr in team_filter:
+            if abbr in seen_teams:
+                continue
+            seen_teams.add(abbr)
+            recent = _fetch_last_game(info, abbr, format_lines, get_cols, requests, game_filter)
+            if recent:
+                games.append(recent)
+
+    return games
+
+
+def _fetch_last_game(info, team_abbr, format_lines, get_cols, requests, game_filter):
+    """Fetch the most recent game for a team via the teams endpoint.
+    Always returns the last completed game regardless of filter."""
+    import logging
+    try:
+        teams_url = f"https://site.api.espn.com/apis/site/v2/sports/{info['path']}/teams?limit=500"
+        team_id = None
+        for page in range(1, 4):
+            url = f"{teams_url}&page={page}"
+            data = requests.get(url, timeout=8).json()
+            batch = data.get('sports', [{}])[0].get('leagues', [{}])[0].get('teams', [])
+            if not batch:
+                break
+            for entry in batch:
+                t = entry.get('team', entry)
+                if t.get('abbreviation', '').upper() == team_abbr:
+                    team_id = t.get('id')
+                    break
+            if team_id:
+                break
+        if not team_id:
+            return None
+
+        sched_url = f"https://site.api.espn.com/apis/site/v2/sports/{info['path']}/teams/{team_id}/schedule"
+        sched = requests.get(sched_url, timeout=8).json()
+        events = sched.get('events', [])
+
+        for event in reversed(events):
+            comps = event.get('competitions', [])
+            if not comps:
+                continue
+            comp = comps[0]
+            state = comp.get('status', {}).get('type', {}).get('state', 'pre')
+            if state != 'post':
+                continue
+            competitors = comp.get('competitors', [])
+            if len(competitors) < 2:
+                continue
+            away = home = None
+            for c in competitors:
+                if c.get('homeAway') == 'home': home = c
+                else: away = c
+            if not away or not home:
+                continue
+            aa = away['team'].get('abbreviation', '???').upper()
+            ha = home['team'].get('abbreviation', '???').upper()
+            as_ = away.get('score', {})
+            hs_ = home.get('score', {})
+            a_score = as_.get('displayValue', str(as_)) if isinstance(as_, dict) else str(as_)
+            h_score = hs_.get('displayValue', str(hs_)) if isinstance(hs_, dict) else str(hs_)
+            score_line = f"{aa} {a_score}  {ha} {h_score}"
+            page = format_lines(info['name'], score_line, "FINAL")
+            return {'page': page, 'score_line': score_line, 'status': 'FINAL', 'state': 'post'}
+        return None
+    except Exception as e:
+        logging.error(f"Schedule fetch error for {team_abbr}: {e}")
+        return None
+
+
+def _parse_events(events, info, team_filter, show_all, format_lines, get_cols, game_filter):
     live, upcoming, final = [], [], []
     for event in events:
         comp = event.get('competitions', [{}])[0]
@@ -65,13 +185,23 @@ def _fetch_league(key, info, team_filter, show_all, format_lines, get_cols, requ
             continue
         state = event.get('status', {}).get('type', {}).get('state', 'pre')
         detail = event.get('status', {}).get('type', {}).get('shortDetail', '')
+
+        # Apply game filter
+        if game_filter == 'live' and state != 'in':
+            continue
+        elif game_filter == 'live+upcoming' and state == 'post':
+            continue
+        elif game_filter == 'live+final' and state == 'pre':
+            continue
+
         if state == 'pre':
-            r2 = f"{aa} VS {ha}"
+            score_line = f"{aa} VS {ha}"
         else:
-            r2 = f"{aa} {away.get('score','0')}  {ha} {home.get('score','0')}"
-        r3 = "FINAL" if state == 'post' else detail.upper()[:15]
-        page = format_lines(info['name'], r2, r3)
-        (live if state == 'in' else upcoming if state == 'pre' else final).append(page)
+            score_line = f"{aa} {away.get('score','0')}  {ha} {home.get('score','0')}"
+        status = "FINAL" if state == 'post' else detail.upper()[:15]
+        page = format_lines(info['name'], score_line, status)
+        game = {'page': page, 'score_line': score_line, 'status': status, 'state': state}
+        (live if state == 'in' else upcoming if state == 'pre' else final).append(game)
     return live + upcoming + final
 
 def _golf(events, info, format_lines):

--- a/apps/sports/manifest.json
+++ b/apps/sports/manifest.json
@@ -1,11 +1,21 @@
 {
   "id": "sports",
   "name": "Sports",
-  "icon": "\ud83c\udfd2",
-  "description": "Live scores",
+  "icon": "🏒",
+  "description": "Scores & Schedules",
   "type": "functional",
-  "refresh_interval": 60,
+  "refresh_interval": 15,
   "loop_delay": 5,
-  "settings": [],
+  "settings": [
+    {
+      "key": "loop_delay",
+      "label": "Delay Between Pages (seconds)",
+      "type": "number",
+      "default": "5",
+      "min": "2",
+      "max": "30",
+      "step": "1"
+    }
+  ],
   "category": "sports"
 }

--- a/apps/star-wars-quotes/manifest.json
+++ b/apps/star-wars-quotes/manifest.json
@@ -8,5 +8,15 @@
   "version": "1.0",
   "refresh_interval": 300,
   "loop_delay": 10,
-  "settings": []
+  "settings": [
+    {
+      "key": "loop_delay",
+      "label": "Delay Between Pages (seconds)",
+      "type": "number",
+      "default": "10",
+      "min": "2",
+      "max": "30",
+      "step": "1"
+    }
+  ]
 }

--- a/apps/stocks/manifest.json
+++ b/apps/stocks/manifest.json
@@ -1,10 +1,21 @@
 {
   "id": "stocks",
   "name": "Stocks",
-  "icon": "\ud83d\udcc8",
+  "icon": "📈",
   "description": "Live prices",
   "type": "functional",
   "refresh_interval": 60,
   "loop_delay": 5,
+  "settings": [
+    {
+      "key": "loop_delay",
+      "label": "Delay Between Pages (seconds)",
+      "type": "number",
+      "default": "5",
+      "min": "2",
+      "max": "30",
+      "step": "1"
+    }
+  ],
   "category": "finance"
 }

--- a/apps/stoic-quotes/manifest.json
+++ b/apps/stoic-quotes/manifest.json
@@ -8,5 +8,15 @@
   "version": "1.0",
   "refresh_interval": 300,
   "loop_delay": 10,
-  "settings": []
+  "settings": [
+    {
+      "key": "loop_delay",
+      "label": "Delay Between Pages (seconds)",
+      "type": "number",
+      "default": "10",
+      "min": "2",
+      "max": "30",
+      "step": "1"
+    }
+  ]
 }

--- a/apps/trivia/manifest.json
+++ b/apps/trivia/manifest.json
@@ -8,5 +8,15 @@
   "version": "1.0",
   "refresh_interval": 300,
   "loop_delay": 10,
-  "settings": []
+  "settings": [
+    {
+      "key": "loop_delay",
+      "label": "Delay Between Pages (seconds)",
+      "type": "number",
+      "default": "10",
+      "min": "2",
+      "max": "30",
+      "step": "1"
+    }
+  ]
 }

--- a/apps/word-of-the-day/manifest.json
+++ b/apps/word-of-the-day/manifest.json
@@ -8,5 +8,15 @@
   "version": "1.0",
   "refresh_interval": 3600,
   "loop_delay": 10,
-  "settings": []
+  "settings": [
+    {
+      "key": "loop_delay",
+      "label": "Delay Between Pages (seconds)",
+      "type": "number",
+      "default": "10",
+      "min": "2",
+      "max": "30",
+      "step": "1"
+    }
+  ]
 }

--- a/apps/yt_comments/manifest.json
+++ b/apps/yt_comments/manifest.json
@@ -1,10 +1,21 @@
 {
   "id": "yt_comments",
   "name": "Comments",
-  "icon": "\ud83d\udcac",
+  "icon": "💬",
   "description": "YT comments",
   "type": "functional",
   "refresh_interval": 60,
   "loop_delay": 8,
+  "settings": [
+    {
+      "key": "loop_delay",
+      "label": "Delay Between Pages (seconds)",
+      "type": "number",
+      "default": "8",
+      "min": "2",
+      "max": "30",
+      "step": "1"
+    }
+  ],
   "category": "data"
 }

--- a/server/app.py
+++ b/server/app.py
@@ -782,19 +782,15 @@ def _run_app_playlist():
                               (app_key in _plugin_registry and _plugin_registry[app_key].get('animation'))
 
                     # Determine per-page delay
+                    reg = app_key[7:] if app_key.startswith('plugin_') else app_key
                     if is_anim:
                         eff_delay = max(0.1, float(settings.get('anim_speed', '0.4')))
-                    elif app_key in _plugin_registry:
-                        eff_delay = float(_plugin_registry[app_key].get('loop_delay', 5))
-                    elif app_key.startswith('plugin_'):
-                        pid = app_key[7:]
-                        eff_delay = float(_plugin_registry.get(pid, {}).get('loop_delay', 5))
-                    elif app_key in ('countdown', 'world_clock'):
-                        eff_delay = 1
-                    elif app_key == 'stocks':
-                        eff_delay = 10
+                    elif reg in _plugin_registry:
+                        saved = settings.get(f'plugin_{reg}_loop_delay', '')
+                        default = float(_plugin_registry[reg].get('loop_delay', settings.get('global_loop_delay', 5)))
+                        eff_delay = float(saved) if saved else default
                     else:
-                        eff_delay = 5
+                        eff_delay = float(settings.get('global_loop_delay', 5))
 
                     active_order = None
                     if is_anim:
@@ -890,10 +886,12 @@ def playlist_loop():
             if reg_key in _plugin_registry:
                 eff_delay = max(0.1, float(_plugin_registry[reg_key].get('loop_delay', eff_delay)))
         elif reg_key in _plugin_registry:
+            saved = settings.get(f'plugin_{reg_key}_loop_delay', '')
             manifest = _plugin_registry[reg_key]
-            eff_delay = float(manifest.get('loop_delay', loop_delay))
+            default = float(manifest.get('loop_delay', settings.get('global_loop_delay', 5)))
+            eff_delay = float(saved) if saved else default
         else:
-            eff_delay = float(loop_delay)
+            eff_delay = float(settings.get('global_loop_delay', loop_delay))
 
         for page in display_pages:
             if stop_event.is_set():
@@ -967,25 +965,10 @@ def handle_settings():
         mod_id = str(data.get('id', '0'))
 
         if action == 'save_global':
-            keys = [
-                'zip_code', 'weather_api_key', 'timezone',
-                'mbta_stop', 'mbta_route', 'stocks_list', 'nhl_teams',
-                'yt_channel_id', 'yt_api_key', 'yt_video_id',
-                'countdown_event', 'countdown_target', 'world_clock_zones',
-                'crypto_list', 'anim_style', 'anim_speed', 'anim_text',
-                'time_format',
-                'livestream_interval', 'livestream_comments',
-                'sports_nfl', 'sports_nba', 'sports_mlb', 'sports_nhl',
-                'sports_ncaaf', 'sports_ncaab', 'sports_mls', 'sports_epl',
-                'sports_laliga', 'sports_ucl', 'sports_wnba', 'sports_pga',
-                'sports_ufc',
-                'mqtt_enabled', 'mqtt_broker', 'mqtt_port', 'mqtt_user', 'mqtt_password',
-                'sim_rows', 'sim_cols',
-                'app_library_url',
-            ]
-            settings.update({k: data[k] for k in keys if k in data})
+            # Save any key except internal/protected ones
+            protected = {'action', 'id', 'offsets', 'calibrations', 'tuned_chars', 'installed_apps', 'saved_playlists', 'saved_app_playlists'}
             for k, v in data.items():
-                if k.startswith("plugin_"):
+                if k not in protected:
                     settings[k] = v
             if 'sim_rows' in data or 'sim_cols' in data:
                 resize_grid()
@@ -1120,15 +1103,17 @@ def run_app():
     # Resolve plugin_ prefix
     registry_key = active_app[7:] if active_app and active_app.startswith('plugin_') else active_app
 
-    # Use loop_delay from plugin manifest if available
+    # Use loop_delay from user settings, then manifest, then global default
     if registry_key in _plugin_registry:
         manifest = _plugin_registry[registry_key]
         if manifest.get('animation'):
             loop_delay = max(0.1, float(settings.get('anim_speed', '0.4')))
         else:
-            loop_delay = float(manifest.get('loop_delay', 5))
+            saved = settings.get(f'plugin_{registry_key}_loop_delay', '')
+            default = float(manifest.get('loop_delay', settings.get('global_loop_delay', 5)))
+            loop_delay = float(saved) if saved else default
     else:
-        loop_delay = 5
+        loop_delay = float(settings.get('global_loop_delay', 5))
 
     stop_event.set()
     mqtt_publish_state()

--- a/server/static/app.js
+++ b/server/static/app.js
@@ -896,7 +896,16 @@ async function buildAppsGrid(){
     const res = await fetch('/installed_apps');
     const data = await res.json();
     const pluginConfigs = data.settings_config || {};
-    Object.assign(APP_SETTINGS_CONFIG, pluginConfigs);
+    // Merge plugin settings with hardcoded configs (don't overwrite, combine fields)
+    for(const [key, cfg] of Object.entries(pluginConfigs)){
+      if(APP_SETTINGS_CONFIG[key]){
+        const existing = APP_SETTINGS_CONFIG[key].fields||[];
+        const newFields = (cfg.fields||[]).filter(f=>!existing.some(e=>e.key===f.key));
+        APP_SETTINGS_CONFIG[key].fields = existing.concat(newFields);
+      } else {
+        APP_SETTINGS_CONFIG[key] = cfg;
+      }
+    }
     (data.apps || []).forEach(a => pluginKeys.add(a.key.replace('plugin_','')));
     (data.apps || []).forEach(a => grid.appendChild(buildAppCard(a, true)));
   } catch(e) { console.error('Failed to load plugins:', e); }
@@ -944,7 +953,7 @@ function buildAppCard(a, isPlugin) {
   const div = document.createElement('div');
   const bareKey = a.key.replace('plugin_','');
   const cfgKey = bareKey in APP_SETTINGS_CONFIG ? bareKey : a.key;
-  const hasCfg = APP_SETTINGS_CONFIG[cfgKey] && (APP_SETTINGS_CONFIG[cfgKey].fields||[]).length > 0;
+  const hasCfg = (APP_SETTINGS_CONFIG[cfgKey] && (APP_SETTINGS_CONFIG[cfgKey].fields||[]).length > 0) || bareKey === 'sports';
   const removable = isPlugin;
   div.className = 'app-card has-app-actions';
   div.dataset.app = a.key;
@@ -1374,6 +1383,7 @@ function loadSettingsData(){
     document.getElementById('autoHomeToggle').checked = data.auto_home;
     document.getElementById('simRows').value = data.sim_rows||3;
     document.getElementById('simCols').value = data.sim_cols||15;
+    document.getElementById('globalLoopDelay').value = data.global_loop_delay||5;
     // MQTT settings
     document.getElementById('mqttEnabled').checked = data.mqtt_enabled !== false;
     document.getElementById('mqttBroker').value = data.mqtt_broker || '';
@@ -1530,11 +1540,13 @@ function setSettingsDirty(isDirty){
 function saveGlobal(){
   const rows = parseInt(document.getElementById('simRows').value) || 3;
   const cols = parseInt(document.getElementById('simCols').value) || 15;
+  const globalDelay = parseInt(document.getElementById('globalLoopDelay').value) || 5;
   const tzEl = document.getElementById('globalTzValue');
   const tz = tzEl ? tzEl.value : '';
   fetch('/settings',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({
     action:'save_global',
     sim_rows:rows, sim_cols:cols,
+    global_loop_delay: globalDelay,
     timezone: tz,
     mqtt_enabled: document.getElementById('mqttEnabled').checked,
     mqtt_broker: document.getElementById('mqttBroker').value,
@@ -2039,11 +2051,49 @@ async function openSportsSettings(){
   document.getElementById('sportsModal').style.display='flex';
   const list = document.getElementById('sportsLeagueList');
   list.innerHTML='<div style="text-align:center;color:#888;padding:20px">Loading leagues…</div>';
+
+  // Fetch fresh settings for display options
+  const settingsRes = await fetch('/settings');
+  const allSettings = await settingsRes.json();
+
   try {
     const res = await fetch('/sports_leagues');
     const data = await res.json();
     _sportsState = {};
     list.innerHTML='';
+
+    // Display settings at top
+    const opts = document.createElement('div');
+    opts.style.cssText='display:flex;flex-wrap:wrap;gap:12px;margin-bottom:16px;padding:10px 14px;background:#1a1a1a;border:1px solid var(--border);border-radius:8px;align-items:center';
+    const filterVal = allSettings.plugin_sports_sports_filter || allSettings.sports_filter || 'all';
+    const leagueVal = allSettings.plugin_sports_sports_show_league || allSettings.sports_show_league || 'yes';
+    const compactVal = allSettings.plugin_sports_sports_compact || allSettings.sports_compact || 'no';
+    opts.innerHTML=`
+      <label style="font-size:.85rem;color:#ccc;display:flex;align-items:center;gap:6px">
+        Show
+        <select id="sportsFilterSelect" style="background:#111;color:#fff;border:1px solid #555;border-radius:4px;padding:4px 6px;font-size:.82rem">
+          <option value="all"${filterVal==='all'?' selected':''}>All Games</option>
+          <option value="live"${filterVal==='live'?' selected':''}>Live Only</option>
+          <option value="live+upcoming"${filterVal==='live+upcoming'?' selected':''}>Live + Upcoming</option>
+          <option value="live+final"${filterVal==='live+final'?' selected':''}>Live + Final</option>
+        </select>
+      </label>
+      <label style="font-size:.85rem;color:#ccc;display:flex;align-items:center;gap:6px">
+        League Name
+        <select id="sportsLeagueToggle" style="background:#111;color:#fff;border:1px solid #555;border-radius:4px;padding:4px 6px;font-size:.82rem">
+          <option value="yes"${leagueVal==='yes'?' selected':''}>Show</option>
+          <option value="no"${leagueVal==='no'?' selected':''}>Hide</option>
+        </select>
+      </label>
+      <label style="font-size:.85rem;color:#ccc;display:flex;align-items:center;gap:6px">
+        Layout
+        <select id="sportsCompactToggle" style="background:#111;color:#fff;border:1px solid #555;border-radius:4px;padding:4px 6px;font-size:.82rem">
+          <option value="no"${compactVal==='no'?' selected':''}>1 Game/Page</option>
+          <option value="yes"${compactVal==='yes'?' selected':''}>2 Games/Page</option>
+        </select>
+      </label>`;
+    list.appendChild(opts);
+
     for(const lg of data.leagues){
       const followed = lg.followed || '';
       _sportsState[lg.key] = {follow_all: followed==='*', teams: new Set(followed==='*'?[]:followed.split(',').filter(t=>t.trim()).map(t=>t.trim().toUpperCase()))};
@@ -2068,7 +2118,17 @@ async function openSportsSettings(){
   } catch(e){ list.innerHTML='<div style="color:var(--red);padding:20px">Failed to load</div>'; }
 }
 
-function closeSportsSettings(){ document.getElementById('sportsModal').style.display='none'; }
+function closeSportsSettings(){
+  // Save display options
+  const filter = document.getElementById('sportsFilterSelect');
+  const league = document.getElementById('sportsLeagueToggle');
+  const compact = document.getElementById('sportsCompactToggle');
+  if(filter && league && compact){
+    fetch('/settings',{method:'POST',headers:{'Content-Type':'application/json'},
+      body:JSON.stringify({action:'save_global', sports_filter:filter.value, sports_show_league:league.value, sports_compact:compact.value})});
+  }
+  document.getElementById('sportsModal').style.display='none';
+}
 
 async function toggleLeague(key){
   const body = document.getElementById(`lbody-${key}`);

--- a/server/static/favicon.svg
+++ b/server/static/favicon.svg
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg id="Layer_1" xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 269.1 267.3">
+  <!-- Generator: Adobe Illustrator 30.0.0, SVG Export Plug-In . SVG Version: 2.1.1 Build 123)  -->
+  <defs>
+    <style>
+      .st0 {
+        fill: #e6e6e6;
+        font-family: DINCondensed-Bold, 'DIN Condensed';
+        font-size: 300px;
+        font-weight: 700;
+      }
+    </style>
+  </defs>
+  <g>
+    <rect x=".5" y="-.4" width="268.1" height="268.1" rx="23.6" ry="23.6"/>
+    <path d="M245,.1c12.7,0,23.1,10.3,23.1,23.1v221c0,12.7-10.3,23.1-23.1,23.1H24.1c-12.7,0-23.1-10.3-23.1-23.1V23.2C1,10.5,11.3.1,24.1.1h221M245-.9H24.1C10.8-.9,0,9.9,0,23.2v221C0,257.4,10.8,268.2,24.1,268.2h221c13.3,0,24.1-10.8,24.1-24.1V23.2c0-13.3-10.8-24.1-24.1-24.1h0Z"/>
+  </g>
+  <text class="st0" transform="translate(9.7 239.8)"><tspan x="0" y="0">OS</tspan></text>
+  <rect y="125" width="269.1" height="17.3"/>
+</svg>

--- a/server/static/logo.svg
+++ b/server/static/logo.svg
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg id="Layer_1" xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 1299.7 267.3">
+  <!-- Generator: Adobe Illustrator 30.0.0, SVG Export Plug-In . SVG Version: 2.1.1 Build 123)  -->
+  <defs>
+    <style>
+      .st0 {
+        fill: #e6e6e6;
+        font-family: DINCondensed-Bold, 'DIN Condensed';
+        font-size: 300px;
+        font-weight: 700;
+      }
+    </style>
+  </defs>
+  <g>
+    <rect x=".5" y="-.4" width="1298.7" height="268.1" rx="23.6" ry="23.6"/>
+    <path d="M1275.6.1c12.7,0,23.1,10.3,23.1,23.1v221c0,12.7-10.3,23.1-23.1,23.1H24.1c-12.7,0-23.1-10.3-23.1-23.1V23.2C1,10.5,11.3.1,24.1.1h1251.6M1275.6-.9H24.1C10.8-.9,0,9.9,0,23.2v221C0,257.4,10.8,268.2,24.1,268.2h1251.6c13.3,0,24.1-10.8,24.1-24.1V23.2c0-13.3-10.8-24.1-24.1-24.1h0Z"/>
+  </g>
+  <text class="st0" transform="translate(4.7 239.8)"><tspan x="0" y="0">SPLITFLAP OS</tspan></text>
+  <rect y="126.8" width="1299.7" height="16.8"/>
+</svg>

--- a/server/templates/index.html
+++ b/server/templates/index.html
@@ -3,7 +3,8 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>Split-Flap OS</title>
+<title>Splitflap OS</title>
+<link rel="icon" type="image/svg+xml" href="/static/favicon.svg">
 <link rel="stylesheet" href="/static/styles.css?v=2">
 <script src="https://unpkg.com/lucide@latest/dist/umd/lucide.min.js"></script>
 </head>
@@ -14,7 +15,7 @@
   <div class="top-bar" id="topBar">
     <div style="display:flex;align-items:center;gap:8px">
       <button class="hamburger-btn" onclick="toggleHamburger()"><i data-lucide="menu" style="width:20px;height:20px"></i></button>
-      <span class="top-bar-title">Split-Flap OS</span>
+      <img src="/static/logo.svg" alt="Splitflap OS" style="height:24px">
     </div>
     <div style="display:flex;align-items:center;gap:6px">
       <span id="simLabel" style="font-size:.82rem;font-weight:bold;color:#555">SIMULATE</span>
@@ -173,6 +174,7 @@
       <div class="settings-grid">
         <div><label class="field-label">Display Rows</label><input type="number" id="simRows" value="3" min="1" max="20" class="line-input" style="font-size:.95rem;margin:0"></div>
         <div><label class="field-label">Display Cols</label><input type="number" id="simCols" value="15" min="1" max="50" class="line-input" style="font-size:.95rem;margin:0"></div>
+        <div><label class="field-label">Delay Between Pages (seconds)</label><input type="number" id="globalLoopDelay" value="5" min="1" max="60" step="1" class="line-input" style="font-size:.95rem;margin:0"></div>
         <div class="span2"><label class="field-label">Timezone</label><div id="globalTzPicker"></div></div>
       </div>
   <button class="settings-fab" id="settingsFab" onclick="saveGlobal()"><i data-lucide="save" style="width:16px;height:16px"></i> Save Settings</button>
@@ -219,7 +221,7 @@
 <!-- HAMBURGER DRAWER -->
 <div class="hamburger-drawer" id="hamburgerDrawer">
   <div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:16px">
-    <span style="font-weight:bold;font-size:1.1rem">Split-Flap OS</span>
+    <img src="/static/logo.svg" alt="Splitflap OS" style="height:22px">
     <button class="drawer-close" onclick="toggleHamburger()"><i data-lucide="x" style="width:18px;height:18px"></i></button>
   </div>
 


### PR DESCRIPTION
## Summary
- Sports app: game filter, league name toggle, compact 2-per-page layout, schedule fallback for off-season, 15s refresh
- Dropped settings whitelist — uses protected-key blocklist instead
- Global + per-app "Delay Between Pages" setting (25 multi-page apps)
- Merged plugin manifest settings with hardcoded APP_SETTINGS_CONFIG
- New SVG logo and favicon

## Test plan
- [ ] Sports: set filter to live/all, toggle league name, compact mode
- [ ] Sports: verify off-season teams show last game
- [ ] Global delay setting on Settings page saves and applies
- [ ] Per-app delay override works (e.g., Stocks gear icon)
- [ ] Logo shows in top bar and hamburger drawer
- [ ] Favicon shows in browser tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)