### PR TITLE
fix: read/write manifests with utf-8 encoding

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -121,7 +121,7 @@ def load_settings():
     }
     if os.path.exists(CONFIG_PATH):
         try:
-            with open(CONFIG_PATH, 'r') as f:
+            with open(CONFIG_PATH, 'r', encoding='utf-8') as f:
                 data = json.load(f)
                 defaults.update(data)
                 if "tuned_chars" not in defaults:
@@ -132,7 +132,7 @@ def load_settings():
     return defaults
 
 def save_settings(data):
-    with open(CONFIG_PATH, 'w') as f:
+    with open(CONFIG_PATH, 'w', encoding='utf-8') as f:
         json.dump(data, f, indent=4)
 
 settings = load_settings()
@@ -595,7 +595,7 @@ def load_installed_plugins():
         if not os.path.isfile(manifest_path):
             continue
         try:
-            with open(manifest_path, "r") as f:
+            with open(manifest_path, "r", encoding='utf-8') as f:
                 manifest = json.load(f)
             manifest["id"] = app_id
             _plugin_registry[app_id] = manifest
@@ -613,7 +613,7 @@ def _load_channel_data(app_id, app_dir):
     if not os.path.isfile(data_path):
         return
     try:
-        with open(data_path, "r") as f:
+        with open(data_path, "r", encoding='utf-8') as f:
             data = json.load(f)
         pages = []
         for page in data.get("pages", []):
@@ -1402,7 +1402,7 @@ def app_library():
             if not os.path.isfile(manifest_path):
                 continue
             try:
-                with open(manifest_path) as f:
+                with open(manifest_path, encoding='utf-8') as f:
                     m = json.load(f)
                 m['id'] = app_id
                 m['installed'] = app_id in _plugin_registry


### PR DESCRIPTION
This pull request updates several file operations in `server/app.py` to explicitly specify UTF-8 encoding when opening files. This change improves compatibility and ensures proper handling of non-ASCII characters, especially when reading or writing JSON files.

This also fixes issues where encoding errors cause the settings cogs from rendering/being shown as well as potentially preventing whole apps from being displayed in the list.

**File handling improvements:**

* Updated all `open()` calls for reading and writing JSON configuration and manifest files to use `encoding='utf-8'` in the following functions: `load_settings`, `save_settings`, `load_installed_plugins`, `_load_channel_data`, and `app_library` (`server/app.py`). [[1]](diffhunk://#diff-675fd40609ae40556a55940d36663ec1f152ec31295f3daa0846c26c72723c4eL124-R124) [[2]](diffhunk://#diff-675fd40609ae40556a55940d36663ec1f152ec31295f3daa0846c26c72723c4eL135-R135) [[3]](diffhunk://#diff-675fd40609ae40556a55940d36663ec1f152ec31295f3daa0846c26c72723c4eL598-R598) [[4]](diffhunk://#diff-675fd40609ae40556a55940d36663ec1f152ec31295f3daa0846c26c72723c4eL616-R616) [[5]](diffhunk://#diff-675fd40609ae40556a55940d36663ec1f152ec31295f3daa0846c26c72723c4eL1405-R1405)