### PR TITLE
Update styles.css for header to prevent overflow on narrow screens.

### DIFF
--- a/server/static/styles.css
+++ b/server/static/styles.css
@@ -322,6 +322,13 @@ input:checked+.slider:before{transform:translateX(20px)}
   .char-matrix{grid-template-columns:repeat(5,1fr)}
 }
 
+@media(max-width:400px){
+  body{padding-top:92px}
+  .top-bar{height:auto;min-height:52px;flex-wrap:wrap;row-gap:6px;padding:8px 12px}
+  .top-bar > :first-child{flex:1 1 auto;min-width:0}
+  .top-bar > :last-child{flex:0 0 100%;justify-content:flex-end}
+}
+
 /* ── SETTINGS FLOATING SAVE FAB ── */
 .settings-fab{position:fixed;left:32px;right:32px;max-width:756px;margin:0 auto;bottom:20px;transform:translateY(20px);background:var(--green);color:#fff;border:none;border-radius:28px;padding:12px 28px;font-size:.95rem;font-weight:700;cursor:pointer;box-shadow:0 4px 18px rgba(0,0,0,.45);opacity:0;pointer-events:none;transition:opacity .22s ease,transform .22s ease;z-index:150;display:flex;align-items:center;justify-content:center;gap:8px}
 .settings-fab.visible{opacity:1;pointer-events:auto;transform:translateY(0)}


### PR DESCRIPTION
This pull request adds responsive design improvements for small screens (max-width 400px) to the server/static/styles.css file. The main change is optimizing the layout of the .top-bar and body padding for mobile devices.

<img width="766" height="386" alt="32d8601350d29445" src="https://github.com/user-attachments/assets/68ad190c-a612-4ac2-932c-83b7d865532d" />

Added a media query for screens with a maximum width of 400px to adjust body padding and .top-bar layout for better usability on small devices. (server/static/styles.css)