### PR TITLE
Feat/computed fields and disabled state

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -840,6 +840,7 @@ def get_plugin_app_list():
 
 _SETTING_PASSTHROUGH_KEYS = (
     "size",
+    "ph",
     "min",
     "max",
     "step",
@@ -848,6 +849,15 @@ _SETTING_PASSTHROUGH_KEYS = (
     "resultKey",
     "maxItems",
     "compute",
+    "compute_config",
+    "disabled_when",
+    "variant",
+    "title",
+    "text",
+    "items",
+    "icon",
+    "linkText",
+    "linkHref",
 )
 
 
@@ -894,6 +904,7 @@ def _normalize_sync_values(sync_values, map_related_key):
 def _build_plugin_setting_field(app_id, setting, resolved_keys):
     raw_key = setting["key"]
     key = resolved_keys[raw_key]
+    field_type = setting.get("type", "text")
 
     def map_related_key(raw_related_key):
         if raw_related_key in resolved_keys:
@@ -902,8 +913,8 @@ def _build_plugin_setting_field(app_id, setting, resolved_keys):
 
     field = {
         "key": key,
-        "label": setting.get("label", raw_key),
-        "type": setting.get("type", "text"),
+        "label": setting.get("label", "" if field_type == "notice" else raw_key),
+        "type": field_type,
         "ph": setting.get("default", ""),
     }
 
@@ -930,6 +941,12 @@ def _build_plugin_setting_field(app_id, setting, resolved_keys):
         field["visible_when"] = {
             map_related_key(k): v
             for k, v in setting["visible_when"].items()
+        }
+
+    if "disabled_when" in setting:
+        field["disabled_when"] = {
+            map_related_key(k): v
+            for k, v in setting["disabled_when"].items()
         }
 
     if "watches" in setting:
@@ -1228,7 +1245,16 @@ threading.Thread(target=playlist_loop, daemon=True).start()
 
 @app.route('/')
 def index():
-    return render_template('index.html', version=_read_version())
+    version = _read_version()
+    static_mtime = 0
+    try:
+        css_mtime = int(os.path.getmtime(os.path.join(app.static_folder, 'styles.css')))
+        js_mtime = int(os.path.getmtime(os.path.join(app.static_folder, 'app.js')))
+        static_mtime = max(css_mtime, js_mtime)
+    except Exception:
+        pass
+    static_v = f"{version}-{static_mtime}" if static_mtime else version
+    return render_template('index.html', version=version, static_v=static_v)
 
 @app.route('/current_state')
 def current_state():

--- a/server/app.py
+++ b/server/app.py
@@ -1246,15 +1246,7 @@ threading.Thread(target=playlist_loop, daemon=True).start()
 @app.route('/')
 def index():
     version = _read_version()
-    static_mtime = 0
-    try:
-        css_mtime = int(os.path.getmtime(os.path.join(app.static_folder, 'styles.css')))
-        js_mtime = int(os.path.getmtime(os.path.join(app.static_folder, 'app.js')))
-        static_mtime = max(css_mtime, js_mtime)
-    except Exception:
-        pass
-    static_v = f"{version}-{static_mtime}" if static_mtime else version
-    return render_template('index.html', version=version, static_v=static_v)
+    return render_template('index.html', version=version)
 
 @app.route('/current_state')
 def current_state():

--- a/server/static/app.js
+++ b/server/static/app.js
@@ -1271,14 +1271,14 @@ FIELD_COMPUTE_FUNCTIONS['polling_usage_estimate'] = function(vals, field){
     : String(vals[selectorIndex] ?? cfg.selector_default ?? '').toLowerCase();
 
   const profiles = (cfg.profiles && typeof cfg.profiles === 'object') ? cfg.profiles : {};
+  const profileKeys = Object.keys(profiles);
   if(!selector){
-    const keys = Object.keys(profiles);
-    const matched = vals.map(v => String(v ?? '').toLowerCase()).find(v => keys.includes(v));
-    selector = matched || String(cfg.selector_default ?? '').toLowerCase() || (keys.length === 1 ? keys[0] : null);
+    const matched = vals.map(v => String(v ?? '').toLowerCase()).find(v => profileKeys.includes(v));
+    selector = matched || String(cfg.selector_default ?? '').toLowerCase() || (profileKeys.length === 1 ? profileKeys[0] : null);
   }
   const selectedProfile = selector && profiles[selector] && typeof profiles[selector] === 'object'
     ? profiles[selector]
-    : (Object.keys(profiles).length === 1 ? profiles[Object.keys(profiles)[0]] : {});
+    : (!selector && profileKeys.length === 1 ? profiles[profileKeys[0]] : {});
 
   const callsPerPoll = resolveCallsPerPoll(selectedProfile, vals, truthyValues);
   const limitPerDay = selectedProfile.limit_per_day == null ? null : Number(selectedProfile.limit_per_day);

--- a/server/static/app.js
+++ b/server/static/app.js
@@ -820,12 +820,17 @@ async function buildAppsGrid(){
     const res = await fetch('/installed_apps');
     const data = await res.json();
     const pluginConfigs = data.settings_config || {};
-    // Merge plugin settings with hardcoded configs (don't overwrite, combine fields)
+    // Merge plugin settings with hardcoded configs.
+    // Prefer latest server definitions for matching keys so schema updates propagate live.
     for(const [key, cfg] of Object.entries(pluginConfigs)){
       if(APP_SETTINGS_CONFIG[key]){
         const existing = APP_SETTINGS_CONFIG[key].fields||[];
-        const newFields = (cfg.fields||[]).filter(f=>!existing.some(e=>e.key===f.key));
-        APP_SETTINGS_CONFIG[key].fields = existing.concat(newFields);
+        const incoming = cfg.fields||[];
+        const incomingByKey = new Map(incoming.map(f => [f.key, f]));
+        const mergedExisting = existing.map(f => incomingByKey.get(f.key) || f);
+        const existingKeys = new Set(existing.map(f => f.key));
+        const appendedIncoming = incoming.filter(f => !existingKeys.has(f.key));
+        APP_SETTINGS_CONFIG[key].fields = mergedExisting.concat(appendedIncoming);
       } else {
         APP_SETTINGS_CONFIG[key] = cfg;
       }
@@ -1167,6 +1172,15 @@ function appendInputWithInlineToggle(div, input, field){
   div.appendChild(row);
 }
 
+function setFieldDisabledState(fieldKey, disabled){
+  const row = document.getElementById(`asf_row_${fieldKey}`);
+  if(!row) return;
+  row.classList.toggle('is-disabled', !!disabled);
+  row.querySelectorAll('input, select, textarea, button').forEach(el=>{
+    el.disabled = !!disabled;
+  });
+}
+
 // ── Number stepper ──────────────────────────────────────────
 function createNumberStepper(input){
   const wrap = document.createElement('div');
@@ -1199,18 +1213,100 @@ function createNumberStepper(input){
 // Return a string, or { text, warn } for warning state.
 const FIELD_COMPUTE_FUNCTIONS = {};
 
-FIELD_COMPUTE_FUNCTIONS['polling_rate_stats'] = function(vals){
-  const rate   = Math.max(1, parseInt(vals[0]) || 60);
-  const source = vals[1] || 'opensky';
-  const perDay   = Math.round(86400 / rate);
-  const perMonth = perDay * 30;
-  const fmt = n => n >= 10000 ? Math.round(n/1000)+'k'
-                 : n >= 1000  ? (n/1000).toFixed(1)+'k'
-                 : String(n);
+function formatCompactCount(n){
+  if(n >= 1000000) return (n / 1000000).toFixed(1) + 'M';
+  if(n >= 10000) return Math.round(n / 1000) + 'k';
+  if(n >= 1000) return (n / 1000).toFixed(1) + 'k';
+  return String(n);
+}
+
+function isTruthySetting(value, truthyValues){
+  const actual = String(value ?? '').toLowerCase();
+  return truthyValues.includes(actual);
+}
+
+function resolveCallsPerPoll(profile, vals, truthyValues){
+  if(!profile || typeof profile !== 'object') return 1;
+  if(profile.call_formula && typeof profile.call_formula === 'object'){
+    const formula = profile.call_formula;
+    const indices = Array.isArray(formula.flag_indices) ? formula.flag_indices : [];
+    const baseCalls = Number(formula.base_calls ?? 1);
+    const perTrueCalls = Number(formula.per_true_calls ?? 1);
+    const trueCount = indices.reduce((count, idx)=>{
+      return count + (isTruthySetting(vals[idx], truthyValues) ? 1 : 0);
+    }, 0);
+    if(formula.type === 'base_plus_any_true'){
+      return baseCalls + (trueCount > 0 ? perTrueCalls : 0);
+    }
+    if(formula.type === 'base_plus_true_count'){
+      return baseCalls + (trueCount * perTrueCalls);
+    }
+    return Math.max(1, Number(profile.calls_per_poll ?? 1));
+  }
+  return Math.max(1, Number(profile.calls_per_poll ?? 1));
+}
+
+function applyTemplate(template, data){
+  return String(template || '').replace(/\{(\w+)\}/g, (_, key)=> {
+    const value = data[key];
+    return value == null ? '' : String(value);
+  });
+}
+
+FIELD_COMPUTE_FUNCTIONS['polling_usage_estimate'] = function(vals, field){
+  const cfg = (field && field.compute_config && typeof field.compute_config === 'object')
+    ? field.compute_config
+    : {};
+
+  const minRate = Math.max(1, Number(cfg.min_rate ?? 1));
+  const defaultRate = Math.max(minRate, Number(cfg.default_rate ?? 60));
+  const rateIndex = Number(cfg.rate_index ?? 0);
+  const rate = Math.max(minRate, parseInt(vals[rateIndex]) || defaultRate);
+  const truthyValues = (Array.isArray(cfg.truthy_values) ? cfg.truthy_values : ['yes', 'true', '1', 'on'])
+    .map(v => String(v).toLowerCase());
+
+  const selectorIndex = cfg.selector_index == null ? null : Number(cfg.selector_index);
+  let selector = selectorIndex == null
+    ? null
+    : String(vals[selectorIndex] ?? cfg.selector_default ?? '').toLowerCase();
+
+  const profiles = (cfg.profiles && typeof cfg.profiles === 'object') ? cfg.profiles : {};
+  if(!selector){
+    const keys = Object.keys(profiles);
+    const matched = vals.map(v => String(v ?? '').toLowerCase()).find(v => keys.includes(v));
+    selector = matched || String(cfg.selector_default ?? '').toLowerCase() || (keys.length === 1 ? keys[0] : null);
+  }
+  const selectedProfile = selector && profiles[selector] && typeof profiles[selector] === 'object'
+    ? profiles[selector]
+    : (Object.keys(profiles).length === 1 ? profiles[Object.keys(profiles)[0]] : {});
+
+  const callsPerPoll = resolveCallsPerPoll(selectedProfile, vals, truthyValues);
+  const limitPerDay = selectedProfile.limit_per_day == null ? null : Number(selectedProfile.limit_per_day);
+  const limitPerMonth = selectedProfile.limit_per_month == null ? null : Number(selectedProfile.limit_per_month);
+  const warnPrefix = String(selectedProfile.warn_prefix || 'Estimated usage exceeds configured limits.');
+  const limitText = String(selectedProfile.limit_text || cfg.default_limit_text || 'Plan dependent');
+
+  const pollsPerDay = Math.ceil(86400 / rate);
+  const reqPerDay = pollsPerDay * callsPerPoll;
+  const reqPerMonth = reqPerDay * 30;
+
   let warn = null;
-  if(source === 'opensky' && perDay > 400)
-    warn = 'Exceeds OpenSky anonymous limit (400 req/day). Register for 4,000/day.';
-  return { text: `~${fmt(perDay)} req/day · ~${fmt(perMonth)}/month`, warn };
+  if(limitPerDay && reqPerDay > limitPerDay){
+    warn = `${warnPrefix} ${formatCompactCount(reqPerDay)}/day exceeds ${formatCompactCount(limitPerDay)}/day.`;
+  } else if(limitPerMonth && reqPerMonth > limitPerMonth){
+    warn = `${warnPrefix} ${formatCompactCount(reqPerMonth)}/month exceeds ${formatCompactCount(limitPerMonth)}/month.`;
+  }
+
+  const textTemplate = String(cfg.text_template || '~{reqPerDay} req/day · ~{reqPerMonth}/month');
+  const text = applyTemplate(textTemplate, {
+    selector,
+    reqPerDay: formatCompactCount(reqPerDay),
+    reqPerMonth: formatCompactCount(reqPerMonth),
+    callsPerPoll,
+    limitText,
+  });
+
+  return { text, warn };
 };
 
 function renderComputedInfo(el, result){
@@ -1233,10 +1329,74 @@ function renderComputedInfo(el, result){
   }
 }
 
+function renderNoticeField(div, field){
+  const box = document.createElement('div');
+  const variant = String(field.variant || 'info').toLowerCase();
+  box.className = `sf-notice sf-notice-${variant}`;
+
+  if(field.icon){
+    const icon = document.createElement('div');
+    icon.className = 'sf-notice-icon';
+    icon.textContent = String(field.icon);
+    box.appendChild(icon);
+  }
+
+  const body = document.createElement('div');
+  body.className = 'sf-notice-body';
+
+  if(field.title){
+    const title = document.createElement('div');
+    title.className = 'sf-notice-title';
+    title.textContent = String(field.title);
+    body.appendChild(title);
+  }
+
+  if(field.text){
+    const text = document.createElement('div');
+    text.className = 'sf-notice-text';
+    text.textContent = String(field.text);
+    body.appendChild(text);
+  }
+
+  if(Array.isArray(field.items) && field.items.length){
+    const list = document.createElement('ul');
+    list.className = 'sf-notice-list';
+    field.items.forEach(item=>{
+      const li = document.createElement('li');
+      li.textContent = String(item);
+      list.appendChild(li);
+    });
+    body.appendChild(list);
+  }
+
+  if(field.linkHref){
+    const link = document.createElement('a');
+    link.className = 'sf-notice-link';
+    link.href = String(field.linkHref);
+    link.target = '_blank';
+    link.rel = 'noopener noreferrer';
+    link.textContent = String(field.linkText || field.linkHref);
+    body.appendChild(link);
+  }
+
+  box.appendChild(body);
+  div.appendChild(box);
+}
+
 function renderAppSettingsField(fieldsContainer, field){
   const div = document.createElement('div');
   div.className = 'modal-field';
   div.id = `asf_row_${field.key}`;
+  if(field.type === 'notice'){
+    if(field.label){
+      const label = document.createElement('label');
+      label.textContent = field.label;
+      div.appendChild(label);
+    }
+    renderNoticeField(div, field);
+    fieldsContainer.appendChild(div);
+    return;
+  }
   const label = document.createElement('label');
   label.textContent = field.label;
   div.appendChild(label);
@@ -1352,6 +1512,12 @@ function wireAppSettingsSyncRules(fields){
   const fieldsByKey = new Map(fields.map(f=>[f.key, f]));
   let syncInProgress = false;
 
+  function conditionMatches(actualValue, expected){
+    const actual = String(actualValue ?? '');
+    if(Array.isArray(expected)) return expected.map(v => String(v)).includes(actual);
+    return actual === String(expected);
+  }
+
   function applySyncValues(sourceKey){
     const source = fieldsByKey.get(sourceKey);
     if(!source || !source.sync_values) return;
@@ -1371,9 +1537,18 @@ function wireAppSettingsSyncRules(fields){
       const row = document.getElementById(`asf_row_${f.key}`);
       if(!row) return;
       const visible = Object.entries(f.visible_when).every(
-        ([parentKey, expected]) => getModalFieldValue(parentKey) === String(expected)
+        ([parentKey, expected]) => conditionMatches(getModalFieldValue(parentKey), expected)
       );
       row.style.display = visible ? '' : 'none';
+    });
+  }
+
+  function applyDisabledState(){
+    fields.forEach(f=>{
+      const disabled = !!f.disabled_when && Object.entries(f.disabled_when).every(
+        ([parentKey, expected]) => conditionMatches(getModalFieldValue(parentKey), expected)
+      );
+      setFieldDisabledState(f.key, disabled);
     });
   }
 
@@ -1391,6 +1566,7 @@ function wireAppSettingsSyncRules(fields){
 
     applySyncValues(fieldKey);
     applyVisibility();
+    applyDisabledState();
   }
 
   function recomputeFields(){
@@ -1401,13 +1577,14 @@ function wireAppSettingsSyncRules(fields){
       const fn = FIELD_COMPUTE_FUNCTIONS[f.compute];
       if(!fn) return;
       const vals = (f.watches || []).map(wk => getModalFieldValue(wk));
-      renderComputedInfo(infoBox, fn(vals));
+      renderComputedInfo(infoBox, fn(vals, f));
     });
   }
 
   fields.forEach(f=> bindModalFieldChange(f.key, ()=> onFieldChanged(f.key)));
   fields.forEach(f=> applySyncValues(f.key));
   applyVisibility();
+  applyDisabledState();
   recomputeFields();
 
   // Re-run computed fields whenever any watched field changes

--- a/server/static/styles.css
+++ b/server/static/styles.css
@@ -182,6 +182,12 @@ input:checked+.slider:before{transform:translateX(20px)}
 .modal-content select option{background:#222}
 .modal-field{margin-bottom:14px}
 .modal-field label{display:block;color:#aaa;font-size:.83rem;margin-bottom:5px}
+.modal-field.is-disabled{opacity:.55}
+.modal-field.is-disabled label{color:#777}
+.modal-field.is-disabled input,
+.modal-field.is-disabled select,
+.modal-field.is-disabled textarea,
+.modal-field.is-disabled button{cursor:not-allowed}
 .password-reveal-wrap{position:relative;display:flex}
 .password-reveal-wrap input{flex:1;padding-right:36px}
 .password-reveal-btn{position:absolute;right:0;top:0;bottom:0;width:34px;background:none;border:none;cursor:pointer;color:#888;display:flex;align-items:center;justify-content:center;font-size:1rem;transition:color .15s}
@@ -203,11 +209,31 @@ input:checked+.slider:before{transform:translateX(20px)}
 .sf-computed-info.warn{border-color:#f59e0b;color:#bbb}
 .sf-computed-warn{display:block;color:#f59e0b;margin-top:3px;font-size:.8rem}
 
+/* ── NOTICE FIELD ── */
+.sf-notice{display:flex;gap:10px;align-items:flex-start;border:1px solid var(--border);border-radius:10px;padding:10px 12px;background:#181818;color:#bbb;line-height:1.5}
+.sf-notice-icon{flex:0 0 auto;font-size:1rem;line-height:1.2;margin-top:1px}
+.sf-notice-body{min-width:0}
+.sf-notice-title{font-size:.86rem;font-weight:700;color:#f2f2f2;margin-bottom:2px}
+.sf-notice-text{font-size:.82rem;color:#b7b7b7}
+.sf-notice-list{margin:6px 0 0 18px;padding:0;color:#b7b7b7;font-size:.82rem}
+.sf-notice-link{display:inline-block;margin-top:6px;font-size:.82rem;color:var(--accent);text-decoration:none}
+.sf-notice-link:hover{text-decoration:underline}
+.sf-notice-info{border-color:#2f4a5e;background:#16212a}
+.sf-notice-warning{border-color:#7a5a12;background:#241b08}
+.sf-notice-warning .sf-notice-title{color:#ffd166}
+.sf-notice-success{border-color:#1f6b4a;background:#10251c}
+.sf-notice-success .sf-notice-title{color:#7ee2a8}
+.sf-notice-error{border-color:#7a2d2d;background:#261111}
+.sf-notice-error .sf-notice-title{color:#ff8a8a}
+
 /* ── APP SETTINGS SEGMENTED TOGGLES ── */
 .sf-segmented-toggle{display:inline-flex;gap:4px;flex-wrap:wrap;padding:3px;border:1px solid var(--border);border-radius:12px;background:#1a1a1a}
 .sf-segmented-toggle-btn{border:none;background:transparent;color:#bbb;border-radius:9px;padding:6px 12px;font-size:.9rem;font-weight:700;cursor:pointer;transition:.15s}
 .sf-segmented-toggle-btn:hover{background:#2b2b2b;color:#fff}
 .sf-segmented-toggle-btn.active{background:var(--accent);color:#000}
+.sf-segmented-toggle-btn:disabled{opacity:.55;cursor:not-allowed}
+.sf-segmented-toggle-btn:disabled:hover{background:transparent;color:#bbb}
+.sf-segmented-toggle-btn.active:disabled{background:#666;color:#ddd}
 .sf-segmented-toggle.sm .sf-segmented-toggle-btn{padding:4px 9px;font-size:.78rem;border-radius:8px}
 .sf-segmented-toggle.md .sf-segmented-toggle-btn{padding:6px 12px;font-size:.9rem;border-radius:9px}
 .sf-segmented-toggle.lg .sf-segmented-toggle-btn{padding:9px 16px;font-size:1rem;border-radius:10px}


### PR DESCRIPTION
### This is a prerequisite to some updates I made to the Weather app, as well as updating the planes overhead app to properly support the new computed fields that calculate the API usage limits and warnings.

This pull request introduces several enhancements to the plugin app settings system, focusing on improved field rendering, dynamic disabling of fields, and more flexible computed field logic. The changes span both backend (`server/app.py`) and frontend (`server/static/app.js`, `server/static/styles.css`), adding new field types (notices), richer field state logic, and improved UI presentation.

**Plugin App Settings System Improvements:**

* Added support for new field types and properties:
  * Backend and frontend now support a `notice` field type, which allows for informational, warning, success, or error messages with icons, titles, lists, and links in settings modals. [[1]](diffhunk://#diff-675fd40609ae40556a55940d36663ec1f152ec31295f3daa0846c26c72723c4eR852-R860) [[2]](diffhunk://#diff-b00398f81bc55184de2a858bf419d242def77cfe797a17b7d3b5b54b62cef5c1R1332-R1399) [[3]](diffhunk://#diff-28fd0c0533a3958e0fd86ec93b47e38e2c9221e2c42b75b276da528c85295bd2R212-R236)
  * New field properties such as `variant`, `title`, `text`, `items`, `icon`, `linkText`, and `linkHref` are supported and passed through from the backend. [[1]](diffhunk://#diff-675fd40609ae40556a55940d36663ec1f152ec31295f3daa0846c26c72723c4eR852-R860) [[2]](diffhunk://#diff-675fd40609ae40556a55940d36663ec1f152ec31295f3daa0846c26c72723c4eR907) [[3]](diffhunk://#diff-b00398f81bc55184de2a858bf419d242def77cfe797a17b7d3b5b54b62cef5c1R1332-R1399)

* Dynamic field state and UI logic:
  * Fields can now be conditionally disabled using a new `disabled_when` property, which is evaluated on the frontend to disable inputs and visually indicate their state. [[1]](diffhunk://#diff-675fd40609ae40556a55940d36663ec1f152ec31295f3daa0846c26c72723c4eR852-R860) [[2]](diffhunk://#diff-675fd40609ae40556a55940d36663ec1f152ec31295f3daa0846c26c72723c4eR946-R951) [[3]](diffhunk://#diff-b00398f81bc55184de2a858bf419d242def77cfe797a17b7d3b5b54b62cef5c1R1175-R1183) [[4]](diffhunk://#diff-b00398f81bc55184de2a858bf419d242def77cfe797a17b7d3b5b54b62cef5c1R1515-R1520) [[5]](diffhunk://#diff-28fd0c0533a3958e0fd86ec93b47e38e2c9221e2c42b75b276da528c85295bd2R185-R190)
  * The logic for showing/hiding and disabling fields is more robust, supporting array-based condition matching and updating both visibility and enabled/disabled state as other fields change. [[1]](diffhunk://#diff-b00398f81bc55184de2a858bf419d242def77cfe797a17b7d3b5b54b62cef5c1R1515-R1520) [[2]](diffhunk://#diff-b00398f81bc55184de2a858bf419d242def77cfe797a17b7d3b5b54b62cef5c1L1374-R1554) [[3]](diffhunk://#diff-b00398f81bc55184de2a858bf419d242def77cfe797a17b7d3b5b54b62cef5c1R1569)

**Computed Field Logic Enhancements:**

* The `polling_usage_estimate` computed field is now much more flexible, supporting configuration objects that define profiles, usage limits, custom warning messages, and text templates. This enables more accurate and context-aware usage estimates and warnings in settings UIs.

**UI/UX Improvements:**

* Improved merging logic for plugin app settings ensures that server-side schema updates propagate live to the frontend, preferring the latest definitions.
* New CSS styles for notice fields and disabled states provide clear visual cues for users, improving accessibility and clarity. [[1]](diffhunk://#diff-28fd0c0533a3958e0fd86ec93b47e38e2c9221e2c42b75b276da528c85295bd2R185-R190) [[2]](diffhunk://#diff-28fd0c0533a3958e0fd86ec93b47e38e2c9221e2c42b75b276da528c85295bd2R212-R236)

<img width="355" height="556" alt="image" src="https://github.com/user-attachments/assets/712b1907-f0bb-44fb-a483-1aa01abcc15e" />


**Other Minor Improvements:**

* Minor refactorings and code cleanups, such as improved variable naming and more explicit value handling in templates.

These changes collectively make the plugin app settings more expressive, maintainable, and user-friendly.