### PR TITLE
Simplify provider profiles and define usage metadata for APIs

### DIFF
--- a/apps/planes_overhead/manifest.json
+++ b/apps/planes_overhead/manifest.json
@@ -73,11 +73,25 @@
       "key": "_polling_stats",
       "label": "API Usage Estimate",
       "type": "computed",
-      "compute": "polling_rate_stats",
+      "compute": "polling_usage_estimate",
       "watches": [
         "polling_rate",
         "data_source"
-      ]
+      ],
+      "compute_config": {
+        "min_rate": 15,
+        "default_rate": 240,
+        "selector_index": 1,
+        "selector_default": "opensky",
+        "text_template": "~{reqPerDay} req/day · ~{reqPerMonth}/month",
+        "profiles": {
+          "opensky": {
+            "calls_per_poll": 1,
+            "limit_per_day": 400,
+            "warn_prefix": "Exceeds OpenSky anonymous limit. Register for 4,000/day."
+          }
+        }
+      }
     },
     {
       "key": "data_source",

--- a/apps/planes_overhead/manifest.json
+++ b/apps/planes_overhead/manifest.json
@@ -84,11 +84,35 @@
         "selector_index": 1,
         "selector_default": "opensky",
         "text_template": "~{reqPerDay} req/day · ~{reqPerMonth}/month",
+        "default_limit_text": "Plan dependent",
         "profiles": {
           "opensky": {
             "calls_per_poll": 1,
             "limit_per_day": 400,
-            "warn_prefix": "Exceeds OpenSky anonymous limit. Register for 4,000/day."
+            "limit_text": "400/day anonymous · 4,000/day registered",
+            "warn_prefix": "Exceeds OpenSky anonymous limit. Register for higher free limits."
+          },
+          "flightaware": {
+            "calls_per_poll": 1,
+            "limit_per_month": 100,
+            "limit_text": "Personal includes about 100 searches/month ($5 free at $0.05/search)",
+            "warn_prefix": "Exceeds FlightAware Personal included usage. Standard and Premium are paid usage-based tiers."
+          },
+          "flightradar24": {
+            "calls_per_poll": 1,
+            "limit_text": "RapidAPI quota varies by subscribed plan"
+          },
+          "airlabs": {
+            "calls_per_poll": 1,
+            "limit_per_month": 1000,
+            "limit_text": "Free plan: 1,000 queries/month",
+            "warn_prefix": "Exceeds AirLabs free plan usage. Paid tiers start at 25,000 queries/month."
+          },
+          "aviationstack": {
+            "calls_per_poll": 1,
+            "limit_per_month": 100,
+            "limit_text": "Free plan: 100 requests/month",
+            "warn_prefix": "Exceeds Aviationstack free plan usage. Paid tiers start at 10,000 requests/month."
           }
         }
       }


### PR DESCRIPTION
### This updates the app to use the neww compute method added in https://github.com/csader/splitflap-os/pull/23

This pull request updates the API usage estimation logic for the `planes_overhead` app by switching to a new compute method and adding a detailed configuration for API usage limits and display. The main changes focus on improving the accuracy and clarity of API usage estimates for different data sources.

**API Usage Estimation Improvements:**

* Changed the `compute` method for the `_polling_stats` field from `polling_rate_stats` to `polling_usage_estimate` to provide more accurate usage calculations.
* Added a comprehensive `compute_config` object for `_polling_stats`, which includes:
  * Minimum and default polling rates, selector settings, and display templates.
