### PR TITLE
feat: rework countdown app

### DIFF
--- a/apps/countdown/app.py
+++ b/apps/countdown/app.py
@@ -1,23 +1,191 @@
 def fetch(settings, format_lines, get_rows, get_cols):
     from datetime import datetime
     import pytz
-    event = settings.get('countdown_event', 'NEW YEAR')
-    target_str = settings.get('countdown_target', '')
-    tz = pytz.timezone(settings.get('timezone', 'US/Eastern'))
-    now = datetime.now(tz)
-    if not target_str:
-        target = now.replace(year=now.year + 1, month=1, day=1, hour=0, minute=0, second=0, microsecond=0)
-    else:
-        target = datetime.fromisoformat(target_str)
+
+    def get_allowed_chars():
+        default_chars = " ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!@#$&()-+=;:%'.,/?*"
+
+        try:
+            import __main__
+
+            source_chars = getattr(__main__, 'FLAP_CHARS', '') or default_chars
+        except Exception:
+            source_chars = default_chars
+
+        # The server stores some flap-only control/color characters in lowercase.
+        return {ch.upper() for ch in str(source_chars)}
+
+    allowed_chars = get_allowed_chars()
+
+    def is_enabled(value, default=False):
+        if value is None:
+            return default
+        return str(value).strip().lower() in {'1', 'true', 'yes', 'on'}
+
+    def clean_event(value, fallback='COUNTDOWN'):
+        text = str(value or '').strip().upper()
+        sanitized = ''.join(ch if ch in allowed_chars else ' ' for ch in text)
+        return sanitized.strip() or fallback
+
+    def clean_target(value):
+        return str(value or '').strip()
+
+    def build_compact_countdown(total_seconds, cols):
+        days, rem = divmod(total_seconds, 86400)
+        hrs, rem = divmod(rem, 3600)
+        mins, secs = divmod(rem, 60)
+
+        # Keep the most useful leading units that still fit on the sign.
+        sections = [
+            f'{days}D',
+            f'{hrs}H',
+            f'{mins}M',
+            f'{secs}S',
+        ]
+
+        text = ''
+        for section in sections:
+            candidate = section if not text else f'{text} {section}'
+            if len(candidate) <= cols:
+                text = candidate
+            else:
+                break
+
+        if text:
+            return text
+        # At the narrowest widths, preserve the day suffix so the value still has context.
+        if cols <= 1:
+            return 'D'[:cols]
+        return f"{str(days)[:cols - 1]}D"
+
+    def build_arrived_text(cols):
+        if cols >= len('ARRIVED!'):
+            return 'ARRIVED!'
+        if cols >= len('HERE!'):
+            return 'HERE!'
+        if cols >= len('NOW!'):
+            return 'NOW!'
+        return 'GO'[:cols]
+
+    def build_celebration_text(cols):
+        if cols >= len('CELEBRATE!'):
+            return 'CELEBRATE!'
+        if cols >= len('PARTY!'):
+            return 'PARTY!'
+        if cols >= len('YAY!'):
+            return 'YAY!'
+        return ''
+
+    def build_remaining_text(cols):
+        if cols >= len('REMAINING'):
+            return 'REMAINING'
+        if cols >= len('LEFT'):
+            return 'LEFT'
+        return ''
+
+    def build_slot_pages(event, target, now, rows, cols):
+        diff = target - now
+        if diff.total_seconds() <= 0:
+            arrived_text = build_arrived_text(cols)
+            if rows == 1:
+                return [format_lines(event[:cols]), format_lines(arrived_text)]
+            if rows == 2:
+                return [format_lines(event, arrived_text)]
+
+            celebration_text = build_celebration_text(cols)
+            return [format_lines(event, arrived_text, celebration_text)]
+
+        total_seconds = max(0, int(diff.total_seconds()))
+        countdown_text = build_compact_countdown(total_seconds, cols)
+
+        if rows == 1:
+            return [format_lines(event[:cols]), format_lines(countdown_text[:cols])]
+        if rows == 2:
+            return [format_lines(event, countdown_text)]
+        return [format_lines(event, countdown_text, build_remaining_text(cols))]
+
+    def parse_target(target_str, tz, now, *, allow_default=False):
+        if not target_str:
+            if not allow_default:
+                return None
+            # Slot 1 keeps legacy behavior by defaulting to the next New Year.
+            return now.replace(
+                year=now.year + 1,
+                month=1,
+                day=1,
+                hour=0,
+                minute=0,
+                second=0,
+                microsecond=0,
+            )
+
+        try:
+            target = datetime.fromisoformat(target_str)
+        except (TypeError, ValueError):
+            return None
+
         if target.tzinfo is None:
             target = tz.localize(target)
-    diff = target - now
-    if diff.total_seconds() <= 0:
-        return [format_lines(event.upper(), 'EVENT ARRIVED', '🎉🎉🎉')]
-    days = diff.days
-    hrs, rem = divmod(diff.seconds, 3600)
-    mins, secs = divmod(rem, 60)
+        return target
+
+    try:
+        tz = pytz.timezone(settings.get('timezone', 'US/Eastern'))
+    except Exception:
+        tz = pytz.timezone('US/Eastern')
+
+    now = datetime.now(tz)
     rows = get_rows()
+    cols = get_cols()
+
+    slots = [
+        {
+            'enabled': is_enabled(settings.get('countdown_enabled', 'on'), default=True),
+            'event': clean_event(
+                settings.get('countdown_event', 'NEW YEAR'),
+                fallback='NEW YEAR',
+            ),
+            'target': clean_target(settings.get('countdown_target', '')),
+            'allow_default_target': True,
+        }
+    ]
+
+    for index in range(2, 6):
+        slots.append(
+            {
+                'enabled': is_enabled(settings.get(f'countdown_{index}_enabled', 'off')),
+                'event': clean_event(settings.get(f'countdown_{index}_event', '')),
+                'target': clean_target(settings.get(f'countdown_{index}_target', '')),
+                'allow_default_target': False,
+            }
+        )
+
+    # If every slot is toggled off, still show slot 1 rather than a blank app.
+    if not any(slot['enabled'] for slot in slots):
+        slots[0]['enabled'] = True
+
+    pages = []
+    for slot in slots:
+        if not slot['enabled']:
+            continue
+
+        if not slot['event'] and not slot['target']:
+            continue
+
+        target = parse_target(
+            slot['target'],
+            tz,
+            now,
+            allow_default=slot['allow_default_target'],
+        )
+        if target is None:
+            continue
+
+        event = slot['event'] or 'COUNTDOWN'
+        pages.extend(build_slot_pages(event, target, now, rows, cols))
+
+    if pages:
+        return pages
+
     if rows == 2:
-        return [format_lines(event.upper(), f'{days}D {hrs}H {mins}M {secs}S')]
-    return [format_lines(event.upper(), f'{days}D {hrs}H {mins}M {secs}S', 'REMAINING')]
+        return [format_lines('COUNTDOWN', 'CHECK CONFIG')]
+    return [format_lines('COUNTDOWN', 'CHECK CONFIG', '')]

--- a/apps/countdown/manifest.json
+++ b/apps/countdown/manifest.json
@@ -9,17 +9,199 @@
   "category": "time",
   "settings": [
     {
+      "key": "countdown_enabled",
+      "label": "Countdown 1",
+      "type": "toggle",
+      "default": "on",
+      "global_key": true,
+      "options": [
+        {
+          "value": "off",
+          "label": "Off"
+        },
+        {
+          "value": "on",
+          "label": "On"
+        }
+      ]
+    },
+    {
       "key": "countdown_event",
-      "label": "Event Name (15 chars)",
+      "label": "Countdown 1 Name (up to sign width)",
       "type": "text",
       "default": "NEW YEAR",
-      "global_key": true
+      "global_key": true,
+      "visible_when": {
+        "countdown_enabled": "on"
+      }
     },
     {
       "key": "countdown_target",
-      "label": "Target Date & Time",
+      "label": "Countdown 1 Target",
       "type": "datetime-local",
-      "global_key": true
+      "global_key": true,
+      "visible_when": {
+        "countdown_enabled": "on"
+      }
+    },
+    {
+      "key": "countdown_2_enabled",
+      "label": "Countdown 2",
+      "type": "toggle",
+      "default": "off",
+      "global_key": true,
+      "options": [
+        {
+          "value": "off",
+          "label": "Off"
+        },
+        {
+          "value": "on",
+          "label": "On"
+        }
+      ]
+    },
+    {
+      "key": "countdown_2_event",
+      "label": "Countdown 2 Name (up to sign width)",
+      "type": "text",
+      "default": "",
+      "global_key": true,
+      "visible_when": {
+        "countdown_2_enabled": "on"
+      }
+    },
+    {
+      "key": "countdown_2_target",
+      "label": "Countdown 2 Target",
+      "type": "datetime-local",
+      "global_key": true,
+      "visible_when": {
+        "countdown_2_enabled": "on"
+      }
+    },
+    {
+      "key": "countdown_3_enabled",
+      "label": "Countdown 3",
+      "type": "toggle",
+      "default": "off",
+      "global_key": true,
+      "options": [
+        {
+          "value": "off",
+          "label": "Off"
+        },
+        {
+          "value": "on",
+          "label": "On"
+        }
+      ]
+    },
+    {
+      "key": "countdown_3_event",
+      "label": "Countdown 3 Name (up to sign width)",
+      "type": "text",
+      "default": "",
+      "global_key": true,
+      "visible_when": {
+        "countdown_3_enabled": "on"
+      }
+    },
+    {
+      "key": "countdown_3_target",
+      "label": "Countdown 3 Target",
+      "type": "datetime-local",
+      "global_key": true,
+      "visible_when": {
+        "countdown_3_enabled": "on"
+      }
+    },
+    {
+      "key": "countdown_4_enabled",
+      "label": "Countdown 4",
+      "type": "toggle",
+      "default": "off",
+      "global_key": true,
+      "options": [
+        {
+          "value": "off",
+          "label": "Off"
+        },
+        {
+          "value": "on",
+          "label": "On"
+        }
+      ]
+    },
+    {
+      "key": "countdown_4_event",
+      "label": "Countdown 4 Name (up to sign width)",
+      "type": "text",
+      "default": "",
+      "global_key": true,
+      "visible_when": {
+        "countdown_4_enabled": "on"
+      }
+    },
+    {
+      "key": "countdown_4_target",
+      "label": "Countdown 4 Target",
+      "type": "datetime-local",
+      "global_key": true,
+      "visible_when": {
+        "countdown_4_enabled": "on"
+      }
+    },
+    {
+      "key": "countdown_5_enabled",
+      "label": "Countdown 5",
+      "type": "toggle",
+      "default": "off",
+      "global_key": true,
+      "options": [
+        {
+          "value": "off",
+          "label": "Off"
+        },
+        {
+          "value": "on",
+          "label": "On"
+        }
+      ]
+    },
+    {
+      "key": "countdown_5_event",
+      "label": "Countdown 5 Name (up to sign width)",
+      "type": "text",
+      "default": "",
+      "global_key": true,
+      "visible_when": {
+        "countdown_5_enabled": "on"
+      }
+    },
+    {
+      "key": "countdown_5_target",
+      "label": "Countdown 5 Target",
+      "type": "datetime-local",
+      "global_key": true,
+      "visible_when": {
+        "countdown_5_enabled": "on"
+      }
+    },
+    {
+      "key": "countdown_warning_all_off",
+      "type": "notice",
+      "variant": "warning",
+      "title": "Slot 1 Fallback",
+      "text": "If all countdown slots are off, Slot 1 will be used.",
+      "global_key": true,
+      "visible_when": {
+        "countdown_enabled": "off",
+        "countdown_2_enabled": "off",
+        "countdown_3_enabled": "off",
+        "countdown_4_enabled": "off",
+        "countdown_5_enabled": "off"
+      }
     },
     {
       "key": "timezone",
@@ -31,6 +213,6 @@
       "global_key": true
     }
   ],
-  "min_rows": 2,
-  "min_cols": 12
+  "min_rows": 1,
+  "min_cols": 6
 }


### PR DESCRIPTION
This pull request adds support for up to five configurable countdown timers in the Countdown app, each with its own event name and target date/time. The app logic is refactored to handle multiple countdowns, including per-countdown enable/disable toggles and improved display handling. The settings UI is updated to allow configuration of each countdown slot, and the minimum sign size requirements are reduced for greater flexibility.

**Multi-countdown support and logic refactor:**

* Refactored `apps/countdown/app.py` to support up to five independent countdown slots, each with its own enable toggle, event name, and target date/time. The app now iterates through enabled countdowns and displays them in order, defaulting to slot 1 if all are off. Display logic is improved for compactness and clarity, with dynamic text sizing and fallback messages.

**Settings and UI enhancements:**

* Updated `apps/countdown/manifest.json` to add per-countdown toggles, event name, and target settings for slots 2–5, all with conditional visibility based on their enabled state. Slot 1 and all additional slots are now individually configurable.
* Added a warning notice in the settings UI to inform users that slot 1 will be used if all countdown slots are disabled.

**Usability improvements:**

* Improved event name and target labels in the settings for clarity, specifying "Countdown N Name (up to sign width)" and "Countdown N Target".
* Reduced the minimum required sign size to 1 row and 6 columns, allowing the app to run on smaller displays.