### PR TITLE
Use venv for Python dependencies, fix Trixie/Bookworm install

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -2232,7 +2232,7 @@ def apply_update():
                 else:
                     subprocess.run(['systemctl', 'restart', 'splitflap.service'], timeout=10)
             except Exception:
-                os.execv('/usr/bin/python3', ['/usr/bin/python3'] + os.sys.argv)
+                os.execv(os.sys.executable, [os.sys.executable] + os.sys.argv)
         threading.Thread(target=_restart, daemon=True).start()
         return jsonify(status='updating', needs_install=needs_install)
     except Exception as e:

--- a/setup/install.sh
+++ b/setup/install.sh
@@ -1,11 +1,12 @@
 #!/bin/bash
-# install.sh — Set up Splitflap OS on a Raspberry Pi (Bookworm)
+# install.sh — Set up Splitflap OS on a Raspberry Pi (Bookworm / Trixie)
 # Run as root from the repo directory: sudo bash setup/install.sh
 
 set -e
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_DIR="$(dirname "$SCRIPT_DIR")"
+VENV_DIR="$REPO_DIR/venv"
 
 echo "=== Splitflap OS Installer ==="
 echo "  Installing from: $REPO_DIR"
@@ -20,7 +21,7 @@ fi
 # Install system packages
 echo "[1/4] Installing system packages..."
 apt-get update -qq
-apt-get install -y -qq python3-pip python3-venv network-manager libopenblas0 > /dev/null
+apt-get install -y python3-pip python3-venv network-manager libopenblas0
 
 # Ensure NetworkManager manages WiFi
 echo "[2/4] Configuring NetworkManager..."
@@ -29,10 +30,17 @@ if ! systemctl is-active --quiet NetworkManager; then
     systemctl start NetworkManager
 fi
 
-# Install Python dependencies
+# Create venv and install Python dependencies
+# Using a venv avoids PEP 668 conflicts on Bookworm/Trixie and keeps
+# dependencies isolated from the system Python.
+# --prefer-binary uses pre-built wheels — much faster on Pi Zero W (ARMv6).
 echo "[3/4] Installing Python dependencies..."
-pip3 install -q --break-system-packages -r "$REPO_DIR/server/requirements.txt" 2>/dev/null || \
-pip3 install -q -r "$REPO_DIR/server/requirements.txt"
+if [ ! -d "$VENV_DIR" ]; then
+    echo "  Creating virtual environment..."
+    python3 -m venv "$VENV_DIR"
+fi
+echo "  Installing packages (this may take a while on Pi Zero W)..."
+"$VENV_DIR/bin/pip" install --prefer-binary -r "$REPO_DIR/server/requirements.txt"
 
 # Make scripts executable
 chmod +x "$REPO_DIR/setup/network-check.sh"

--- a/setup/splitflap.service
+++ b/setup/splitflap.service
@@ -7,7 +7,7 @@ Wants=splitflap-network.service
 Type=simple
 User=root
 WorkingDirectory=/opt/splitflap-os/server
-ExecStart=/usr/bin/python3 -c "import app; app.app.run(host='0.0.0.0', port=80)"
+ExecStart=/opt/splitflap-os/venv/bin/python -c "import app; app.app.run(host='0.0.0.0', port=80)"
 Restart=on-failure
 RestartSec=5
 Environment=SPLITFLAP_CONFIG=/opt/splitflap-os/server/settings.json


### PR DESCRIPTION
## Problem
On Raspberry Pi OS Trixie (and Bookworm), `pip install` fails with `externally-managed-environment` (PEP 668). The previous workaround used `--break-system-packages` which works but is fragile.

## Changes
- `install.sh` creates a venv at `$REPO_DIR/venv` and installs into it — clean isolation, no system Python conflicts, works on all Debian versions
- `--prefer-binary` uses pre-built wheels instead of compiling from source — significantly faster on Pi Zero W (ARMv6 can take 30–60 min compiling numpy/pandas)
- Verbose output during install so progress is visible
- `setup/splitflap.service` ExecStart updated to use `venv/bin/python`
- `server/app.py` apply_update fallback uses `sys.executable` instead of hardcoded `/usr/bin/python3`

## Migration
Existing installs: re-run `sudo bash setup/install.sh` — it will create the venv and reinstall. The service will be updated automatically.

## Test plan
- [ ] Fresh install on Trixie — no PEP 668 error
- [ ] Fresh install on Bookworm — works as before
- [ ] Service starts correctly using venv python
- [ ] OTA update via UI restarts correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)