### PR TITLE
Add SplitFlap Gateway as a target for the app

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Built on [Adam G Makes' Split-Flap Display](https://github.com/adamgmakes/SplitF
 - **Calibration tools** — hardware inspector, auto fine-tune, teach mode
 - **MQTT** — Home Assistant integration with auto-discovery
 - **Configurable serial port** — auto-detect available ports or enter a custom path; supports env var, settings UI, and Docker deployments
+- **SplitFlap Gateway (MQTT)** — alternatively drive the display remotely through an ESP32 gateway over MQTT instead of a local serial port; configure broker, port, topic prefix, and optional credentials in the settings UI
 - **WiFi hotspot fallback** — Pi creates its own network when no WiFi is found, so you can always access the UI
 - **Offline resilience** — internet-dependent apps degrade gracefully, offline apps keep running
 - **Plugin architecture** — community apps via manifest + fetch pattern
@@ -62,6 +63,34 @@ sudo bash setup/install.sh
 This project is the **web UI only**. For the firmware and physical display hardware (3D printed parts, PCBs, BOM), see the original project by Adam G Makes:
 
 **https://github.com/adamgmakes/SplitFlapDisplay**
+
+## SplitFlap Gateway (MQTT)
+
+Instead of a local serial connection, SplitFlap OS can drive the display through a **SplitFlap Gateway** (an ESP32 running `SplitFlapGateway_2.ino`) over MQTT. This is useful when the display and the server aren't physically wired together.
+
+Switch modes under **Settings > Hardware Connection > Connection Type**. When "SplitFlap Gateway (MQTT)" is selected, enter the broker address, port, topic prefix, and optional username/password, then click **Connect Gateway**.
+
+SplitFlap OS only interacts with two topics, so the impact on the rest of the system is minimal:
+
+| Topic | Direction | Payload |
+|-------|-----------|---------|
+| `<prefix>/send` | OS → gateway | Raw RS485 frame (e.g. `m05-A\n`), forwarded verbatim to the bus |
+| `<prefix>/rx`   | gateway → OS | JSON `{"command":"<frame>", ...}` for each frame received from a module |
+
+The gateway transport presents the same interface as a serial port internally, so calibration, EEPROM sync, and all display writes work identically in either mode.
+
+These settings can also be supplied via environment variables (useful for Docker/headless deployments), which take precedence over the settings file:
+
+```
+SPLITFLAP_CONNECTION_TYPE=gateway     # 'serial' (default) or 'gateway'
+SPLITFLAP_GATEWAY_BROKER=192.168.1.50
+SPLITFLAP_GATEWAY_PORT=1883
+SPLITFLAP_GATEWAY_PREFIX=splitflap
+SPLITFLAP_GATEWAY_USER=               # optional
+SPLITFLAP_GATEWAY_PASSWORD=           # optional
+```
+
+> Note: this MQTT connection (display transport) is independent of the existing **MQTT / Home Assistant** integration (state publishing & control), which continues to use its own broker settings.
 
 ## Repo Structure
 

--- a/server/app.py
+++ b/server/app.py
@@ -47,31 +47,44 @@ def _read_config_file():
             pass
     return {}
 
-def _get_serial_port():
-    """Resolve serial port: env var > settings.json > default."""
+def _get_serial_port(data=None):
+    """Resolve serial port: env var > settings.json > default.
+
+    Pass an already-loaded settings dict as ``data`` to avoid re-reading
+    settings.json (see _open_connection).
+    """
     env_port = os.environ.get("SPLITFLAP_SERIAL_PORT")
     if env_port:
         return env_port
-    data = _read_config_file()
+    if data is None:
+        data = _read_config_file()
     if data.get("serial_port"):
         return data["serial_port"]
     return SERIAL_PORT_DEFAULT
 
-def _get_connection_type():
+def _get_connection_type(data=None):
     """Resolve the active connection type: env var > settings.json > 'serial'.
 
     Returns either 'serial' (local USB/serial port) or 'gateway' (MQTT
-    SplitFlap Gateway).
+    SplitFlap Gateway). Pass an already-loaded settings dict as ``data`` to
+    avoid re-reading settings.json.
     """
     env_type = os.environ.get("SPLITFLAP_CONNECTION_TYPE")
     if env_type:
         return env_type.strip().lower()
-    ct = _read_config_file().get("connection_type", "serial")
+    if data is None:
+        data = _read_config_file()
+    ct = data.get("connection_type", "serial")
     return (ct or "serial").strip().lower()
 
-def _get_gateway_config():
-    """Pull the gateway MQTT settings from env/settings.json."""
-    data = _read_config_file()
+def _get_gateway_config(data=None):
+    """Pull the gateway MQTT settings from env/settings.json.
+
+    Pass an already-loaded settings dict as ``data`` to avoid re-reading
+    settings.json.
+    """
+    if data is None:
+        data = _read_config_file()
     return {
         "broker":   os.environ.get("SPLITFLAP_GATEWAY_BROKER",   data.get("gateway_broker", "")),
         "port":     int(os.environ.get("SPLITFLAP_GATEWAY_PORT", data.get("gateway_port", 1883)) or 1883),
@@ -137,9 +150,12 @@ def _open_connection():
     pyserial-compatible surface in both modes, so all downstream code is
     agnostic to which one is active.
     """
-    if _get_connection_type() == "gateway":
-        return _open_gateway()
-    return _open_serial()
+    # Read settings.json once and thread it through the resolvers below so
+    # startup doesn't re-open the file for each setting it needs.
+    data = _read_config_file()
+    if _get_connection_type(data) == "gateway":
+        return _open_gateway(_get_gateway_config(data))
+    return _open_serial(_get_serial_port(data))
 
 ser, SERIAL_PORT = _open_connection()
 
@@ -704,6 +720,13 @@ def connection_config():
 
     data = request.json or {}
     conn_type = (data.get('type') or 'serial').strip().lower()
+
+    if conn_type not in ('serial', 'gateway'):
+        return jsonify(
+            status="error",
+            message=f"Unknown connection type '{conn_type}' "
+                    "(expected 'serial' or 'gateway')",
+        ), 400
 
     if conn_type == 'gateway':
         broker = (data.get('broker') or '').strip()

--- a/server/app.py
+++ b/server/app.py
@@ -21,6 +21,13 @@ except ImportError:
     mqtt = None
     logging.warning("paho-mqtt not installed — MQTT integration disabled")
 
+try:
+    from gateway_transport import GatewayTransport, GatewayConnectionError
+except ImportError:
+    GatewayTransport = None
+    class GatewayConnectionError(Exception):
+        pass
+
 SERIAL_PORT_DEFAULT = '/dev/ttyUSB0'
 BAUD_RATE = 9600
 CONFIG_PATH = os.environ.get(
@@ -30,20 +37,48 @@ CONFIG_PATH = os.environ.get(
 APPS_PATH = os.path.join(os.path.dirname(__file__), '..', 'apps')
 VERSION_FILE = os.path.join(os.path.dirname(__file__), '..', 'VERSION')
 
+def _read_config_file():
+    """Read the on-disk settings.json (best-effort) before load_settings runs."""
+    if os.path.exists(CONFIG_PATH):
+        try:
+            with open(CONFIG_PATH, 'r', encoding='utf-8') as f:
+                return json.load(f)
+        except Exception:
+            pass
+    return {}
+
 def _get_serial_port():
     """Resolve serial port: env var > settings.json > default."""
     env_port = os.environ.get("SPLITFLAP_SERIAL_PORT")
     if env_port:
         return env_port
-    if os.path.exists(CONFIG_PATH):
-        try:
-            with open(CONFIG_PATH, 'r', encoding='utf-8') as f:
-                data = json.load(f)
-                if data.get("serial_port"):
-                    return data["serial_port"]
-        except Exception:
-            pass
+    data = _read_config_file()
+    if data.get("serial_port"):
+        return data["serial_port"]
     return SERIAL_PORT_DEFAULT
+
+def _get_connection_type():
+    """Resolve the active connection type: env var > settings.json > 'serial'.
+
+    Returns either 'serial' (local USB/serial port) or 'gateway' (MQTT
+    SplitFlap Gateway).
+    """
+    env_type = os.environ.get("SPLITFLAP_CONNECTION_TYPE")
+    if env_type:
+        return env_type.strip().lower()
+    ct = _read_config_file().get("connection_type", "serial")
+    return (ct or "serial").strip().lower()
+
+def _get_gateway_config():
+    """Pull the gateway MQTT settings from env/settings.json."""
+    data = _read_config_file()
+    return {
+        "broker":   os.environ.get("SPLITFLAP_GATEWAY_BROKER",   data.get("gateway_broker", "")),
+        "port":     int(os.environ.get("SPLITFLAP_GATEWAY_PORT", data.get("gateway_port", 1883)) or 1883),
+        "prefix":   os.environ.get("SPLITFLAP_GATEWAY_PREFIX",   data.get("gateway_prefix", "splitflap")),
+        "user":     os.environ.get("SPLITFLAP_GATEWAY_USER",     data.get("gateway_user", "")),
+        "password": os.environ.get("SPLITFLAP_GATEWAY_PASSWORD", data.get("gateway_password", "")),
+    }
 
 def _read_version():
     try:
@@ -68,7 +103,45 @@ def _open_serial(port=None):
         logging.error(f"Serial failed on {port}. Simulation Mode. Reason: {e}")
         return None, port
 
-ser, SERIAL_PORT = _open_serial()
+def _open_gateway(cfg=None):
+    """Open an MQTT gateway connection. Returns (GatewayTransport, label) or (None, label)."""
+    cfg = cfg or _get_gateway_config()
+    label = f"gateway:{cfg.get('broker','')}:{cfg.get('port',1883)}"
+    if GatewayTransport is None:
+        logging.error("Gateway selected but paho-mqtt/gateway_transport unavailable. Simulation Mode.")
+        return None, label
+    if not cfg.get("broker"):
+        logging.error("Gateway selected but no broker configured. Simulation Mode.")
+        return None, label
+    try:
+        t = GatewayTransport(
+            broker=cfg["broker"],
+            port=cfg.get("port", 1883),
+            prefix=cfg.get("prefix", "splitflap"),
+            username=cfg.get("user", ""),
+            password=cfg.get("password", ""),
+        )
+        logging.info(f"Gateway connected: {label} prefix={cfg.get('prefix','splitflap')}")
+        return t, label
+    except GatewayConnectionError as e:
+        logging.error(f"Gateway failed ({label}). Simulation Mode. Reason: {e}")
+        return None, label
+    except Exception as e:
+        logging.error(f"Gateway error ({label}). Simulation Mode. Reason: {e}")
+        return None, label
+
+def _open_connection():
+    """Open the active connection based on the configured connection type.
+
+    Returns (transport_or_None, descriptor_string). The transport exposes a
+    pyserial-compatible surface in both modes, so all downstream code is
+    agnostic to which one is active.
+    """
+    if _get_connection_type() == "gateway":
+        return _open_gateway()
+    return _open_serial()
+
+ser, SERIAL_PORT = _open_connection()
 
 # --- GLOBAL STATE ---
 FLAP_CHARS = " ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!@#$&()-+=;q:%'.,/?*roygbpw"
@@ -156,6 +229,12 @@ def load_settings():
         "quiet_hours_end": "07:00",
         "quiet_hours_days": ["sun","mon","tue","wed","thu","fri","sat"],
         "serial_port": "",
+        "connection_type": "serial",
+        "gateway_broker":   "",
+        "gateway_port":     1883,
+        "gateway_prefix":   "splitflap",
+        "gateway_user":     "",
+        "gateway_password": "",
         "triggers_enabled": True,
         "triggers": [],
         "installed_apps": [
@@ -570,7 +649,11 @@ def list_serial_ports():
 
 @app.route('/serial_port', methods=['POST'])
 def set_serial_port():
-    """Change the active serial port and persist to settings."""
+    """Change the active serial port and persist to settings.
+
+    Applying a serial port also switches the active connection type back to
+    'serial' (in case the gateway was previously selected).
+    """
     global ser, sim_mode, SERIAL_PORT
     data = request.json
     new_port = data.get('port', '').strip()
@@ -587,8 +670,105 @@ def set_serial_port():
         sim_mode = not ser
 
     settings['serial_port'] = new_port
+    settings['connection_type'] = 'serial'
     save_settings(settings)
     return jsonify(status="success", port=SERIAL_PORT, sim_mode=sim_mode)
+
+
+@app.route('/connection', methods=['GET', 'POST'])
+def connection_config():
+    """Get or set the active hardware connection (serial vs MQTT gateway).
+
+    POST body (gateway):
+        {"type":"gateway","broker":"...","port":1883,"prefix":"splitflap",
+         "user":"","password":""}
+    POST body (serial):
+        {"type":"serial","port":"/dev/ttyUSB0"}   # port optional
+    """
+    global ser, sim_mode, SERIAL_PORT
+    if request.method == 'GET':
+        return jsonify(
+            type=settings.get('connection_type', 'serial'),
+            serial_port=settings.get('serial_port', ''),
+            gateway_broker=settings.get('gateway_broker', ''),
+            gateway_port=settings.get('gateway_port', 1883),
+            gateway_prefix=settings.get('gateway_prefix', 'splitflap'),
+            gateway_user=settings.get('gateway_user', ''),
+            # Password intentionally not echoed back in full for safety;
+            # report whether one is set instead.
+            gateway_password_set=bool(settings.get('gateway_password', '')),
+            sim_mode=sim_mode,
+            connected=ser is not None,
+            descriptor=SERIAL_PORT,
+        )
+
+    data = request.json or {}
+    conn_type = (data.get('type') or 'serial').strip().lower()
+
+    if conn_type == 'gateway':
+        broker = (data.get('broker') or '').strip()
+        if not broker:
+            return jsonify(status="error", message="Broker address is required"), 400
+        prefix = (data.get('prefix') or 'splitflap').strip() or 'splitflap'
+        try:
+            gw_port = int(data.get('port', 1883) or 1883)
+        except (TypeError, ValueError):
+            return jsonify(status="error", message="Invalid port"), 400
+        user = (data.get('user') or '').strip()
+        # Preserve the existing password if the field is left blank on resubmit.
+        password = data.get('password', None)
+        if password is None or password == '':
+            password = settings.get('gateway_password', '')
+
+        # Persist before (re)connecting so _open_gateway picks up fresh values.
+        settings['connection_type'] = 'gateway'
+        settings['gateway_broker'] = broker
+        settings['gateway_port'] = gw_port
+        settings['gateway_prefix'] = prefix
+        settings['gateway_user'] = user
+        settings['gateway_password'] = password
+        save_settings(settings)
+
+        with serial_lock:
+            if ser:
+                try:
+                    ser.close()
+                except Exception:
+                    pass
+            ser, SERIAL_PORT = _open_gateway({
+                "broker": broker, "port": gw_port, "prefix": prefix,
+                "user": user, "password": password,
+            })
+            sim_mode = not ser
+        return jsonify(
+            status="success",
+            type="gateway",
+            descriptor=SERIAL_PORT,
+            sim_mode=sim_mode,
+            message="Gateway connected" if not sim_mode
+                    else "Saved, but could not reach gateway — simulation mode",
+        )
+
+    # Fall back to serial.
+    settings['connection_type'] = 'serial'
+    save_settings(settings)
+    with serial_lock:
+        if ser:
+            try:
+                ser.close()
+            except Exception:
+                pass
+        port = (data.get('port') or settings.get('serial_port') or '').strip() or None
+        ser, SERIAL_PORT = _open_serial(port)
+        sim_mode = not ser
+    return jsonify(
+        status="success",
+        type="serial",
+        descriptor=SERIAL_PORT,
+        sim_mode=sim_mode,
+        message="Serial connected" if not sim_mode
+                else "Saved, but could not open serial — simulation mode",
+    )
 
 
 # ============================================================

--- a/server/gateway_transport.py
+++ b/server/gateway_transport.py
@@ -40,6 +40,7 @@ splitflap-os footprint.
 
 import json
 import logging
+import os
 import threading
 import time
 
@@ -88,7 +89,10 @@ class GatewayTransport:
         self._connected = threading.Event()
         self._closed = False
 
-        client_id = f"splitflap-os-{int(time.time())}"
+        # Include the PID so a crash-loop restart within the same second (common
+        # on a Pi) doesn't collide with the previous session's client ID, which
+        # would cause the broker to kick one of the two connections.
+        client_id = f"splitflap-os-{os.getpid()}-{int(time.time())}"
         self._client = mqtt.Client(
             mqtt.CallbackAPIVersion.VERSION2, client_id=client_id
         )
@@ -189,8 +193,24 @@ class GatewayTransport:
         """
         if isinstance(data, str):
             data = data.encode()
+        if not self._connected.is_set():
+            # The broker is down / mid-reconnect. paho will silently queue (or
+            # drop) the publish, so the frame may never reach the display and
+            # the caller gets no signal. Surface the loss -- it matters most
+            # during calibration / EEPROM writes, where a dropped frame leaves
+            # the module in an inconsistent state.
+            logging.warning(
+                "Gateway(MQTT) not connected; command may not reach display: %r",
+                data,
+            )
         # paho accepts bytes payloads directly.
-        self._client.publish(self.send_topic, payload=data, qos=0)
+        info = self._client.publish(self.send_topic, payload=data, qos=0)
+        rc = getattr(info, "rc", 0)
+        if rc != 0:
+            logging.warning(
+                "Gateway(MQTT) publish failed (rc=%s); command not sent: %r",
+                rc, data,
+            )
         return len(data)
 
     def flush(self):

--- a/server/gateway_transport.py
+++ b/server/gateway_transport.py
@@ -1,0 +1,235 @@
+"""
+gateway_transport.py
+====================
+
+A drop-in, serial-compatible transport that talks to a *SplitFlap Gateway*
+(an ESP32 running SplitFlapGateway_2.ino) over MQTT instead of a local serial
+port.
+
+The rest of splitflap-os was written against a pyserial ``Serial`` object and
+uses only a small slice of its API:
+
+    * ``.write(bytes)``        -> send a frame to the bus
+    * ``.flush()``             -> no-op for us (MQTT publish is already flushed)
+    * ``.reset_input_buffer()``-> drop any buffered RX data
+    * ``.in_waiting``          -> number of RX bytes available to read
+    * ``.read(n)``             -> read up to ``n`` RX bytes
+    * ``.close()``             -> tear down
+
+``GatewayTransport`` implements exactly that surface so the existing call sites
+in app.py work unchanged.
+
+Protocol (see SplitFlapGateway_2.ino):
+
+    App -> Gateway   topic  <prefix>/send
+        The gateway accepts a *plain* RS485 frame as the payload (e.g.
+        ``b"m05-A\n"``) and forwards it verbatim onto the bus.  We publish the
+        exact bytes the old code used to write to the serial port.
+
+    Gateway -> App   topic  <prefix>/rx
+        For every frame the gateway *receives back* from a module it publishes
+        JSON: ``{"ts":<ms>,"wt":"<walltime>","command":"<ascii frame>"}``.
+        The ``command`` field holds the ASCII frame with its trailing newline
+        stripped.  We re-append a newline and feed the bytes into an internal
+        RX buffer so the existing ``in_waiting`` / ``read`` loops (which scan
+        for target strings like ``m05d:...``) behave just like a serial port.
+
+Only those two topics are touched, matching the requirement to minimise the
+splitflap-os footprint.
+"""
+
+import json
+import logging
+import threading
+import time
+
+try:
+    import paho.mqtt.client as mqtt
+except ImportError:  # pragma: no cover - handled by caller
+    mqtt = None
+
+
+class GatewayConnectionError(Exception):
+    """Raised when the gateway broker cannot be reached at startup."""
+
+
+class GatewayTransport:
+    """Serial-compatible facade over an MQTT SplitFlap Gateway.
+
+    Parameters
+    ----------
+    broker : str
+        MQTT broker hostname / IP.
+    port : int
+        MQTT broker port (typically 1883).
+    prefix : str
+        Topic prefix configured on the gateway (default ``splitflap``).
+        We only ever use ``<prefix>/send`` and ``<prefix>/rx``.
+    username, password : str, optional
+        MQTT credentials.  Leave blank for an anonymous broker.
+    connect_timeout : float
+        Seconds to wait for the initial connection before giving up.
+    """
+
+    def __init__(self, broker, port=1883, prefix="splitflap",
+                 username="", password="", connect_timeout=8.0):
+        if mqtt is None:
+            raise GatewayConnectionError("paho-mqtt is not installed")
+
+        self.broker = broker
+        self.port = int(port)
+        self.prefix = (prefix or "splitflap").strip().rstrip("/")
+        self.send_topic = f"{self.prefix}/send"
+        self.rx_topic = f"{self.prefix}/rx"
+
+        # Internal RX byte buffer, emulating a serial input buffer.
+        self._rx_buf = bytearray()
+        self._rx_lock = threading.Lock()
+        self._connected = threading.Event()
+        self._closed = False
+
+        client_id = f"splitflap-os-{int(time.time())}"
+        self._client = mqtt.Client(
+            mqtt.CallbackAPIVersion.VERSION2, client_id=client_id
+        )
+        if username:
+            self._client.username_pw_set(username, password or "")
+        self._client.on_connect = self._on_connect
+        self._client.on_disconnect = self._on_disconnect
+        self._client.on_message = self._on_message
+
+        logging.info(
+            "Gateway(MQTT) connecting to %s:%s prefix=%s",
+            self.broker, self.port, self.prefix,
+        )
+        try:
+            self._client.connect(self.broker, self.port, keepalive=30)
+        except Exception as e:
+            raise GatewayConnectionError(
+                f"could not reach gateway broker {self.broker}:{self.port}: {e}"
+            )
+        self._client.loop_start()
+
+        # Block briefly so the caller can fall back to simulation if the broker
+        # is unreachable -- mirrors how _open_serial() fails fast.
+        if not self._connected.wait(timeout=connect_timeout):
+            self.close()
+            raise GatewayConnectionError(
+                f"timed out connecting to gateway broker "
+                f"{self.broker}:{self.port}"
+            )
+
+    # ------------------------------------------------------------------
+    # MQTT callbacks
+    # ------------------------------------------------------------------
+    def _on_connect(self, client, userdata, flags, reason_code, properties=None):
+        # paho VERSION2 passes a ReasonCode object; 0 / "Success" == OK.
+        ok = (getattr(reason_code, "value", reason_code) == 0)
+        if ok:
+            client.subscribe(self.rx_topic, qos=0)
+            self._connected.set()
+            logging.info(
+                "Gateway(MQTT) connected; subscribed to %s", self.rx_topic
+            )
+        else:
+            logging.error("Gateway(MQTT) connect failed: %s", reason_code)
+
+    def _on_disconnect(self, client, userdata, *args):
+        self._connected.clear()
+        if not self._closed:
+            logging.warning("Gateway(MQTT) disconnected; will auto-reconnect")
+
+    def _on_message(self, client, userdata, msg):
+        if msg.topic != self.rx_topic:
+            return
+        frame = self._extract_frame(msg.payload)
+        if frame is None:
+            return
+        # Re-append the newline the gateway stripped so downstream parsers that
+        # look for '\n' terminators behave exactly as with raw serial.
+        data = frame.encode("utf-8", errors="ignore") + b"\n"
+        with self._rx_lock:
+            self._rx_buf.extend(data)
+
+    @staticmethod
+    def _extract_frame(payload):
+        """Pull the ASCII frame out of an /rx payload.
+
+        Accepts the gateway's JSON form ``{"command":"..."}`` and also a bare
+        plain-text frame, for robustness against future gateway changes.
+        """
+        try:
+            text = payload.decode("utf-8", errors="ignore")
+        except Exception:
+            return None
+        text = text.strip()
+        if not text:
+            return None
+        if text[0] == "{":
+            try:
+                doc = json.loads(text)
+            except Exception:
+                return None
+            cmd = doc.get("command")
+            if cmd is None:
+                return None
+            return str(cmd)
+        # Plain frame fallback.
+        return text
+
+    # ------------------------------------------------------------------
+    # pyserial-compatible surface
+    # ------------------------------------------------------------------
+    def write(self, data):
+        """Publish a raw frame to ``<prefix>/send``.
+
+        ``data`` is bytes (as the existing code passes ``cmd.encode()``).
+        The gateway forwards the payload to the bus verbatim, so we publish the
+        exact bytes -- including the trailing newline -- unchanged.
+        """
+        if isinstance(data, str):
+            data = data.encode()
+        # paho accepts bytes payloads directly.
+        self._client.publish(self.send_topic, payload=data, qos=0)
+        return len(data)
+
+    def flush(self):
+        # Publishing is synchronous from the caller's perspective; nothing to do.
+        return None
+
+    def reset_input_buffer(self):
+        with self._rx_lock:
+            self._rx_buf.clear()
+
+    # reset_output_buffer is referenced by some pyserial code paths; provide it
+    # for completeness even though splitflap-os doesn't call it.
+    def reset_output_buffer(self):
+        return None
+
+    @property
+    def in_waiting(self):
+        with self._rx_lock:
+            return len(self._rx_buf)
+
+    def read(self, size=1):
+        with self._rx_lock:
+            if size <= 0:
+                return b""
+            chunk = bytes(self._rx_buf[:size])
+            del self._rx_buf[:size]
+            return chunk
+
+    @property
+    def is_open(self):
+        return self._connected.is_set()
+
+    def close(self):
+        self._closed = True
+        try:
+            self._client.loop_stop()
+        except Exception:
+            pass
+        try:
+            self._client.disconnect()
+        except Exception:
+            pass

--- a/server/static/app.js
+++ b/server/static/app.js
@@ -2066,6 +2066,7 @@ function loadSettingsData(){
     selectModule(selectedModule);
     setSettingsDirty(false);
     refreshSerialPorts();
+    loadConnectionConfig();
   });
 }
 
@@ -2133,11 +2134,74 @@ function applySerialPort(){
       if(data.status==='success'){
         status.textContent = data.sim_mode ? 'Set (simulation — could not open)' : 'Connected';
         status.style.color = data.sim_mode ? '#f90' : '#0f0';
+        const ctSel = document.getElementById('connectionType');
+        if(ctSel){ ctSel.value = 'serial'; onConnectionTypeChange('serial'); }
         showToast(data.sim_mode ? 'Port saved but could not open — simulation mode' : 'Serial port connected');
       } else {
         status.textContent = data.message||'Error';
         status.style.color = '#f44';
         showToast(data.message||'Error setting port','error');
+      }
+    }).catch(()=>{
+      status.textContent = 'Request failed';
+      status.style.color = '#f44';
+    });
+}
+
+// --- Hardware Connection (serial vs MQTT gateway) UI ---
+function onConnectionTypeChange(val){
+  const isGw = val === 'gateway';
+  document.getElementById('connSerialPanel').style.display = isGw ? 'none' : '';
+  document.getElementById('connGatewayPanel').style.display = isGw ? '' : 'none';
+}
+
+function loadConnectionConfig(){
+  fetch('/connection').then(r=>r.json()).then(data=>{
+    const type = data.type || 'serial';
+    const sel = document.getElementById('connectionType');
+    if(sel) sel.value = type;
+    document.getElementById('gatewayBroker').value = data.gateway_broker || '';
+    document.getElementById('gatewayPort').value = data.gateway_port || 1883;
+    document.getElementById('gatewayPrefix').value = data.gateway_prefix || 'splitflap';
+    document.getElementById('gatewayUser').value = data.gateway_user || '';
+    // Password is never echoed; show a placeholder hint if one is set.
+    const pwEl = document.getElementById('gatewayPassword');
+    pwEl.value = '';
+    pwEl.placeholder = data.gateway_password_set ? '•••••• (leave blank to keep current)' : '(optional)';
+    onConnectionTypeChange(type);
+    if(type === 'gateway'){
+      const status = document.getElementById('gatewayStatus');
+      if(status){
+        status.textContent = data.sim_mode ? 'Not connected (simulation)' : 'Connected';
+        status.style.color = data.sim_mode ? '#f90' : '#0f0';
+      }
+    }
+  });
+}
+
+function applyGatewayConnection(){
+  const broker = document.getElementById('gatewayBroker').value.trim();
+  if(!broker){ showToast('Enter the MQTT broker address','error'); return; }
+  const port = parseInt(document.getElementById('gatewayPort').value) || 1883;
+  const prefix = document.getElementById('gatewayPrefix').value.trim() || 'splitflap';
+  const user = document.getElementById('gatewayUser').value.trim();
+  const password = document.getElementById('gatewayPassword').value; // blank = keep current
+  const status = document.getElementById('gatewayStatus');
+  status.textContent = 'Connecting...';
+  status.style.color = '#888';
+  fetch('/connection',{method:'POST',headers:{'Content-Type':'application/json'},
+    body:JSON.stringify({type:'gateway', broker, port, prefix, user, password})})
+    .then(r=>r.json()).then(data=>{
+      if(data.status==='success'){
+        status.textContent = data.sim_mode ? 'Saved (gateway unreachable — simulation)' : 'Connected';
+        status.style.color = data.sim_mode ? '#f90' : '#0f0';
+        showToast(data.message || 'Gateway settings saved');
+        // Clear the password field; it's persisted server-side now.
+        document.getElementById('gatewayPassword').value = '';
+      } else {
+        status.textContent = data.message || 'Error';
+        status.style.color = '#f44';
+        showToast(data.message || 'Error connecting gateway','error');
       }
     }).catch(()=>{
       status.textContent = 'Request failed';

--- a/server/templates/index.html
+++ b/server/templates/index.html
@@ -270,25 +270,53 @@
   <button class="settings-fab" id="settingsFab" onclick="saveGlobal()"><i data-lucide="save" style="width:16px;height:16px"></i> Save Settings</button>
     </div>
     <div class="config-section">
-      <h3>Serial Port</h3>
-      <p style="color:#888;font-size:.85rem;margin-top:0">Select a detected port or enter a custom path (e.g. /tmp/ttyVSF0).</p>
+      <h3>Hardware Connection</h3>
+      <p style="color:#888;font-size:.85rem;margin-top:0">Choose how splitflap-os talks to the display: directly over a local serial port, or remotely via a <strong>SplitFlap Gateway</strong> over MQTT.</p>
       <div class="settings-grid">
         <div class="span2">
-          <label class="field-label">Port</label>
-          <div style="display:flex;gap:8px;align-items:center">
-            <select id="serialPortSelect" class="line-input" style="font-size:.9rem;margin:0;flex:1" onchange="onSerialPortSelect(this.value)">
-              <option value="">Loading...</option>
-            </select>
-            <button class="btn btn-secondary btn-sm" onclick="refreshSerialPorts()" title="Refresh"><i data-lucide="refresh-cw" style="width:14px;height:14px"></i></button>
-          </div>
-        </div>
-        <div class="span2" id="serialPortManualWrap" style="display:none">
-          <label class="field-label">Custom Path</label>
-          <input type="text" id="serialPortManual" class="line-input" style="font-size:.95rem;margin:0" placeholder="/dev/ttyUSB0 or /tmp/ttyVSF0">
+          <label class="field-label">Connection Type</label>
+          <select id="connectionType" class="line-input" style="font-size:.9rem;margin:0" onchange="onConnectionTypeChange(this.value)">
+            <option value="serial">Serial Port (local USB)</option>
+            <option value="gateway">SplitFlap Gateway (MQTT)</option>
+          </select>
         </div>
       </div>
-      <button class="btn btn-success btn-sm" style="margin-top:10px" onclick="applySerialPort()">Apply</button>
-      <span id="serialPortStatus" style="margin-left:10px;font-size:.85rem;color:#888"></span>
+
+      <!-- Serial panel -->
+      <div id="connSerialPanel" style="margin-top:14px">
+        <p style="color:#888;font-size:.85rem;margin-top:0">Select a detected port or enter a custom path (e.g. /tmp/ttyVSF0).</p>
+        <div class="settings-grid">
+          <div class="span2">
+            <label class="field-label">Port</label>
+            <div style="display:flex;gap:8px;align-items:center">
+              <select id="serialPortSelect" class="line-input" style="font-size:.9rem;margin:0;flex:1" onchange="onSerialPortSelect(this.value)">
+                <option value="">Loading...</option>
+              </select>
+              <button class="btn btn-secondary btn-sm" onclick="refreshSerialPorts()" title="Refresh"><i data-lucide="refresh-cw" style="width:14px;height:14px"></i></button>
+            </div>
+          </div>
+          <div class="span2" id="serialPortManualWrap" style="display:none">
+            <label class="field-label">Custom Path</label>
+            <input type="text" id="serialPortManual" class="line-input" style="font-size:.95rem;margin:0" placeholder="/dev/ttyUSB0 or /tmp/ttyVSF0">
+          </div>
+        </div>
+        <button class="btn btn-success btn-sm" style="margin-top:10px" onclick="applySerialPort()">Apply</button>
+        <span id="serialPortStatus" style="margin-left:10px;font-size:.85rem;color:#888"></span>
+      </div>
+
+      <!-- Gateway (MQTT) panel -->
+      <div id="connGatewayPanel" style="margin-top:14px;display:none">
+        <p style="color:#888;font-size:.85rem;margin-top:0">splitflap-os publishes frames to <code>&lt;prefix&gt;/send</code> and listens on <code>&lt;prefix&gt;/rx</code>. Make sure these match the gateway's configured topic prefix.</p>
+        <div class="settings-grid">
+          <div><label class="field-label">Broker Address</label><input type="text" id="gatewayBroker" class="line-input" style="font-size:.95rem;margin:0" placeholder="192.168.1.50 or mqtt.local"></div>
+          <div><label class="field-label">Port</label><input type="number" id="gatewayPort" class="line-input" style="font-size:.95rem;margin:0" value="1883"></div>
+          <div><label class="field-label">Topic Prefix</label><input type="text" id="gatewayPrefix" class="line-input" style="font-size:.95rem;margin:0" placeholder="splitflap"></div>
+          <div><label class="field-label">Username <span style="color:#666">(optional)</span></label><input type="text" id="gatewayUser" class="line-input" style="font-size:.95rem;margin:0" placeholder="(optional)"></div>
+          <div class="span2"><label class="field-label">Password <span style="color:#666">(optional)</span></label><input type="password" id="gatewayPassword" class="line-input" style="font-size:.95rem;margin:0" placeholder="(leave blank to keep current)"></div>
+        </div>
+        <button class="btn btn-success btn-sm" style="margin-top:10px" onclick="applyGatewayConnection()">Connect Gateway</button>
+        <span id="gatewayStatus" style="margin-left:10px;font-size:.85rem;color:#888"></span>
+      </div>
     </div>
     <div class="config-section">
       <h3>WiFi / Network</h3>
@@ -325,6 +353,7 @@
     </div>
     <div class="config-section">
       <h3>MQTT / Home Assistant</h3>
+      <p style="color:#888;font-size:.85rem;margin-top:0">Publishes display state and accepts control commands for Home Assistant. This is separate from the <strong>SplitFlap Gateway</strong> hardware connection above.</p>
       <div class="settings-grid">
         <div class="span2" style="display:flex;align-items:center;gap:10px">
           <label class="field-label" style="margin:0">Enabled</label>


### PR DESCRIPTION

# SplitFlap Gateway (MQTT) Integration — Change Summary

This adds an option to drive the display through a **SplitFlap Gateway**
([Waveshare ESP32-S3-RS485-CAN](https://www.waveshare.com/wiki/ESP32-S3-RS485-CAN) running SplitFlap Gateway firmware at [https://github.com/avandeputte/SplitFlapGateway](https://github.com/avandeputte/SplitFlapGateway) ) over MQTT, as an alternative to a
local serial port. The design goal was to **minimize impact** on the existing
splitflap-os codebase: the OS interacts with only two topics —
`<prefix>/send` and `<prefix>/rx`.


## How it works

A new transport class presents the *same interface* the existing code already
used for the serial port (`.write()`, `.flush()`, `.reset_input_buffer()`,
`.in_waiting`, `.read()`, `.close()`). Because of this, none of the existing
read/write call sites had to change.

- **OS → Gateway** on `<prefix>/send`: the exact RS485 frame bytes the old
  code wrote to the serial port (e.g. `m05-A\n`, `m05c\n`, `m05d\n`) are
  published verbatim. The gateway forwards them straight to the bus.
- **Gateway → OS** on `<prefix>/rx`: the gateway publishes JSON
  `{"ts":...,"wt":"...","command":"<ascii frame>"}` for each frame received
  from a module. The transport extracts `command`, re-appends the newline the
  gateway stripped, and buffers it so the existing calibration / EEPROM-dump
  read loops parse it exactly as they did with serial.

The gateway MQTT connection is **independent** of the pre-existing
MQTT / Home Assistant integration (which publishes state and accepts control
commands). They use separate clients and settings.

## Files changed

### New: `server/gateway_transport.py`
`GatewayTransport`, a pyserial-compatible facade over MQTT. Touches only
`<prefix>/send` (publish) and `<prefix>/rx` (subscribe). Fails fast on an
unreachable broker so the app can fall back to simulation mode, mirroring how
serial failure is handled.

### `server/app.py`
- Import `GatewayTransport` (graceful fallback if unavailable).
- New settings keys with defaults: `connection_type` (`serial`|`gateway`),
  `gateway_broker`, `gateway_port`, `gateway_prefix`, `gateway_user`,
  `gateway_password`.
- `_read_config_file()`, `_get_connection_type()`, `_get_gateway_config()`
  helpers (readable at startup, before `load_settings()` runs).
- `_open_gateway()` and `_open_connection()`; startup now calls
  `_open_connection()`, which dispatches on `connection_type`.
- `/serial_port` now also sets `connection_type='serial'` when applied.
- New `/connection` route (GET/POST) to view/switch/configure the connection.
  Password is preserved on blank resubmit and never echoed back in full.
- **No existing `ser.write()` / `ser.read()` call sites were modified.**

### `server/templates/index.html`
- "Serial Port" settings panel replaced by a "Hardware Connection" panel with
  a Connection Type selector toggling between the serial panel and a new
  gateway panel (broker, port, topic prefix, optional username/password).
- Added a clarifying note on the existing "MQTT / Home Assistant" section.

### `server/static/app.js`
- `onConnectionTypeChange()`, `loadConnectionConfig()`,
  `applyGatewayConnection()`; `loadSettingsData()` now also loads the
  connection config; applying a serial port syncs the type selector.

### `README.md`
- Feature bullet + a "SplitFlap Gateway (MQTT)" section documenting the topic
  contract and environment variables.

## Environment variables (optional, override settings.json)

```
SPLITFLAP_CONNECTION_TYPE=gateway     # 'serial' (default) or 'gateway'
SPLITFLAP_GATEWAY_BROKER=192.168.1.50
SPLITFLAP_GATEWAY_PORT=1883
SPLITFLAP_GATEWAY_PREFIX=splitflap
SPLITFLAP_GATEWAY_USER=               # optional
SPLITFLAP_GATEWAY_PASSWORD=           # optional
```

## Dependencies

`paho-mqtt` was already present in `requirements.txt`; no new dependency added.

