### PR TITLE
Add Universal Firmware provisioning support

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Built on [Adam G Makes' Split-Flap Display](https://github.com/adamgmakes/SplitF
 - **Playlists** — sequence apps and composed messages with per-entry timing and transitions
 - **Live preview** — animated flap simulation in the browser
 - **Calibration tools** — hardware inspector, auto fine-tune, teach mode
+- **Universal Firmware provisioning** — automatically discover, identify, assign, diagnose, and de-provision modules from the calibration page
 - **MQTT** — Home Assistant integration with auto-discovery
 - **Configurable serial port** — auto-detect available ports or enter a custom path; supports env var, settings UI, and Docker deployments
 - **SplitFlap Gateway (MQTT)** — alternatively drive the display remotely through an ESP32 gateway over MQTT instead of a local serial port; configure broker, port, topic prefix, and optional credentials in the settings UI
@@ -91,6 +92,22 @@ SPLITFLAP_GATEWAY_PASSWORD=           # optional
 ```
 
 > Note: this MQTT connection (display transport) is independent of the existing **MQTT / Home Assistant** integration (state publishing & control), which continues to use its own broker settings.
+## Universal Firmware
+
+Universal Firmware is an **optional alternative** to the original per-module
+firmware. It lets every module run the same firmware image instead of compiling
+a different build for each module ID. IDs are assigned later over RS-485,
+making it much easier to add, replace, or rearrange modules.
+
+You can find and download the universal version of the firmware from
+[avandeputte/SplitFlapUniversalFirmware](https://github.com/avandeputte/SplitFlapUniversalFirmware).
+When it is used, Splitflap OS can discover new modules, identify them by moving
+the reel, assign IDs, and run supported diagnostics from the Calibration page.
+The original module firmware remains supported.
+
+Learn more: [firmware and protocol documentation](https://github.com/avandeputte/SplitFlapUniversalFirmware/blob/main/README.md)
+| [`provision.py` example](https://github.com/avandeputte/SplitFlapUniversalFirmware/blob/main/provision.py)
+| [architecture notes](https://github.com/avandeputte/SplitFlapUniversalFirmware/blob/main/ARCHITECTURE.md)
 
 ## Repo Structure
 
@@ -113,7 +130,17 @@ For full app-development documentation, settings schema, and examples, see [APPS
 
 ## Attribution
 
-Based on the [Split-Flap Display](https://github.com/adamgmakes/SplitFlapDisplay) by **Adam G Makes**, licensed under [CC BY-NC-SA 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/).
+- Splitflap OS is based on the
+  [Split-Flap Display](https://github.com/adamgmakes/SplitFlapDisplay) by
+  **Adam G Makes**, licensed under
+  [CC BY-NC-SA 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/).
+
+- Thanks to **[@avandeputte](https://github.com/avandeputte)** for
+  [SplitFlapUniversalFirmware](https://github.com/avandeputte/SplitFlapUniversalFirmware),
+  its documented RS-485 provisioning protocol and `provision.py` reference, and
+  [SplitFlapGateway](https://github.com/avandeputte/SplitFlapGateway), whose
+  [web UI](https://github.com/avandeputte/SplitFlapGateway#web-ui) helped inform
+  this independent provisioning interface.
 
 ## License
 

--- a/server/app.py
+++ b/server/app.py
@@ -175,7 +175,6 @@ universal_firmware = UniversalFirmwareManager(
     serial_lock=serial_lock,
     get_sim_mode=lambda: sim_mode,
 )
-universal_firmware.start()
 
 
 # ============================================================
@@ -812,17 +811,24 @@ def _universal_error_response(exc, status=400):
     return jsonify(status="error", message=str(exc)), status
 
 
+def _ensure_universal_firmware_started():
+    universal_firmware.ensure_started()
+    return universal_firmware
+
+
 @app.route('/universal/status')
 def universal_status():
     """Return Universal Firmware modules and recent unprovisioned adverts."""
-    return jsonify(universal_firmware.status(get_module_count()))
+    manager = _ensure_universal_firmware_started()
+    return jsonify(manager.status(get_module_count()))
 
 
 @app.route('/universal/scan', methods=['POST'])
 def universal_scan():
     """Discover provisioned Universal Firmware modules in the configured grid."""
+    manager = _ensure_universal_firmware_started()
     try:
-        universal_firmware.scan(get_module_count() - 1)
+        manager.scan(get_module_count() - 1)
         return jsonify(status="scanning")
     except UniversalFirmwareError as exc:
         return _universal_error_response(exc)
@@ -831,12 +837,13 @@ def universal_scan():
 @app.route('/universal/home', methods=['POST'])
 def universal_home():
     """Home a provisioned module by ID or an unprovisioned module by serial."""
+    manager = _ensure_universal_firmware_started()
     data = request.get_json(silent=True) or {}
     try:
         if data.get('serial'):
-            universal_firmware.home_by_serial(data['serial'])
+            manager.home_by_serial(data['serial'])
         elif data.get('id') is not None:
-            universal_firmware.home_module(data['id'])
+            manager.home_module(data['id'])
         else:
             return jsonify(status="error", message="serial or id is required"), 400
         return jsonify(status="sent")
@@ -847,9 +854,10 @@ def universal_home():
 @app.route('/universal/provision', methods=['POST'])
 def universal_provision():
     """Assign an ID by chip serial and wait for the firmware acknowledgement."""
+    manager = _ensure_universal_firmware_started()
     data = request.get_json(silent=True) or {}
     try:
-        acknowledged = universal_firmware.provision(
+        acknowledged = manager.provision(
             data.get('serial'),
             data.get('id'),
         )
@@ -870,12 +878,13 @@ def universal_provision():
 @app.route('/universal/deprovision', methods=['POST'])
 def universal_deprovision():
     """Reset one module's ID, or every module when ``all`` is explicitly true."""
+    manager = _ensure_universal_firmware_started()
     data = request.get_json(silent=True) or {}
     try:
         if data.get('all') is True:
-            universal_firmware.deprovision_all()
+            manager.deprovision_all()
             return jsonify(status="sent", message="All modules are returning to provisioning mode.")
-        universal_firmware.deprovision(data.get('id'))
+        manager.deprovision(data.get('id'))
         return jsonify(status="sent", message="Module is returning to provisioning mode.")
     except UniversalFirmwareError as exc:
         return _universal_error_response(exc)
@@ -884,9 +893,10 @@ def universal_deprovision():
 @app.route('/universal/diagnose', methods=['POST'])
 def universal_diagnose():
     """Run a Universal Firmware Q, T, or M diagnostic transaction."""
+    manager = _ensure_universal_firmware_started()
     data = request.get_json(silent=True) or {}
     try:
-        result = universal_firmware.run_diagnostic(
+        result = manager.run_diagnostic(
             data.get('id'),
             kind=data.get('kind', 'snapshot'),
             revolutions=data.get('revolutions', 5),

--- a/server/app.py
+++ b/server/app.py
@@ -14,6 +14,10 @@ import urllib.request
 import shutil
 from datetime import datetime
 from flask import Flask, render_template, request, jsonify
+from hardware.universal_firmware import (
+    UniversalFirmwareError,
+    UniversalFirmwareManager,
+)
 
 try:
     import paho.mqtt.client as mqtt
@@ -165,6 +169,13 @@ current_indices = [-1] * 45  # resized after settings load
 current_display_string = " " * 45
 is_homed = False
 sim_mode = not ser  # auto-enable simulation if no serial hardware
+
+universal_firmware = UniversalFirmwareManager(
+    get_serial=lambda: ser,
+    serial_lock=serial_lock,
+    get_sim_mode=lambda: sim_mode,
+)
+universal_firmware.start()
 
 
 # ============================================================
@@ -684,6 +695,7 @@ def set_serial_port():
                 pass
         ser, SERIAL_PORT = _open_serial(new_port)
         sim_mode = not ser
+        universal_firmware.reset()
 
     settings['serial_port'] = new_port
     settings['connection_type'] = 'serial'
@@ -763,6 +775,7 @@ def connection_config():
                 "user": user, "password": password,
             })
             sim_mode = not ser
+            universal_firmware.reset()
         return jsonify(
             status="success",
             type="gateway",
@@ -784,6 +797,7 @@ def connection_config():
         port = (data.get('port') or settings.get('serial_port') or '').strip() or None
         ser, SERIAL_PORT = _open_serial(port)
         sim_mode = not ser
+        universal_firmware.reset()
     return jsonify(
         status="success",
         type="serial",
@@ -792,6 +806,94 @@ def connection_config():
         message="Serial connected" if not sim_mode
                 else "Saved, but could not open serial — simulation mode",
     )
+
+
+def _universal_error_response(exc, status=400):
+    return jsonify(status="error", message=str(exc)), status
+
+
+@app.route('/universal/status')
+def universal_status():
+    """Return Universal Firmware modules and recent unprovisioned adverts."""
+    return jsonify(universal_firmware.status(get_module_count()))
+
+
+@app.route('/universal/scan', methods=['POST'])
+def universal_scan():
+    """Discover provisioned Universal Firmware modules in the configured grid."""
+    try:
+        universal_firmware.scan(get_module_count() - 1)
+        return jsonify(status="scanning")
+    except UniversalFirmwareError as exc:
+        return _universal_error_response(exc)
+
+
+@app.route('/universal/home', methods=['POST'])
+def universal_home():
+    """Home a provisioned module by ID or an unprovisioned module by serial."""
+    data = request.get_json(silent=True) or {}
+    try:
+        if data.get('serial'):
+            universal_firmware.home_by_serial(data['serial'])
+        elif data.get('id') is not None:
+            universal_firmware.home_module(data['id'])
+        else:
+            return jsonify(status="error", message="serial or id is required"), 400
+        return jsonify(status="sent")
+    except UniversalFirmwareError as exc:
+        return _universal_error_response(exc)
+
+
+@app.route('/universal/provision', methods=['POST'])
+def universal_provision():
+    """Assign an ID by chip serial and wait for the firmware acknowledgement."""
+    data = request.get_json(silent=True) or {}
+    try:
+        acknowledged = universal_firmware.provision(
+            data.get('serial'),
+            data.get('id'),
+        )
+        response = {
+            "status": "success" if acknowledged else "unconfirmed",
+            "acknowledged": acknowledged,
+            "message": (
+                "Module acknowledged its new ID."
+                if acknowledged
+                else "No acknowledgement was received. The assignment may still have succeeded."
+            ),
+        }
+        return jsonify(response), 200 if acknowledged else 202
+    except UniversalFirmwareError as exc:
+        return _universal_error_response(exc)
+
+
+@app.route('/universal/deprovision', methods=['POST'])
+def universal_deprovision():
+    """Reset one module's ID, or every module when ``all`` is explicitly true."""
+    data = request.get_json(silent=True) or {}
+    try:
+        if data.get('all') is True:
+            universal_firmware.deprovision_all()
+            return jsonify(status="sent", message="All modules are returning to provisioning mode.")
+        universal_firmware.deprovision(data.get('id'))
+        return jsonify(status="sent", message="Module is returning to provisioning mode.")
+    except UniversalFirmwareError as exc:
+        return _universal_error_response(exc)
+
+
+@app.route('/universal/diagnose', methods=['POST'])
+def universal_diagnose():
+    """Run a Universal Firmware Q, T, or M diagnostic transaction."""
+    data = request.get_json(silent=True) or {}
+    try:
+        result = universal_firmware.run_diagnostic(
+            data.get('id'),
+            kind=data.get('kind', 'snapshot'),
+            revolutions=data.get('revolutions', 5),
+        )
+        return jsonify(status="success", result=result)
+    except UniversalFirmwareError as exc:
+        return _universal_error_response(exc, 504)
 
 
 # ============================================================

--- a/server/hardware/__init__.py
+++ b/server/hardware/__init__.py
@@ -1,0 +1,1 @@
+"""Hardware protocol and transport integrations for Splitflap OS."""

--- a/server/hardware/universal_firmware.py
+++ b/server/hardware/universal_firmware.py
@@ -1,0 +1,515 @@
+"""Universal Split-Flap Firmware discovery, provisioning, and diagnostics.
+
+The manager passively observes the shared serial bus without replacing the
+application's existing synchronous calibration transactions. Every serial read
+is protected by the same lock used by the rest of Splitflap OS, so a long
+calibration or EEPROM read keeps exclusive ownership of its response.
+"""
+
+from collections import deque
+import logging
+import re
+import threading
+import time
+
+
+SERIAL_RE = re.compile(r"^[0-9A-F]{20}$")
+ADVERTISEMENT_RE = re.compile(r"^mXadv:([0-9A-Fa-f]{20})$")
+# Firmware examples exist with and without the colon after "mXack".
+ACK_RE = re.compile(r"^mXack:?([0-9A-Fa-f]{20}):(\d{1,3})$")
+VERSION_RE = re.compile(
+    r"^m(\d+)v:([^:\s]+)(?::(\d+):([0-9A-Fa-f]{20}))?$"
+)
+SNAPSHOT_RE = re.compile(
+    r"^m(\d+)Q:(\d+):(\d+):(\d+):(\d+):(-?\d+)$"
+)
+HALL_RE = re.compile(
+    r"^m(\d+)T:(\d+):(\d+):(\d+)(?::(\d+))?$"
+)
+MECHANICAL_RE = re.compile(r"^m(\d+)M:(.*)$")
+
+
+class UniversalFirmwareError(RuntimeError):
+    """A user-facing Universal Firmware operation error."""
+
+
+def parse_firmware_number(value):
+    """Return the numeric part of a firmware version such as ``v29``."""
+    match = re.search(r"\d+", str(value or ""))
+    return int(match.group(0)) if match else 0
+
+
+def parse_universal_line(line):
+    """Parse one RS-485 response line into a normalized event dictionary."""
+    line = str(line or "").strip()
+    if not line:
+        return None
+
+    match = ADVERTISEMENT_RE.match(line)
+    if match:
+        return {"type": "advertisement", "serial": match.group(1).upper()}
+
+    match = ACK_RE.match(line)
+    if match:
+        module_id = int(match.group(2))
+        if module_id <= 254:
+            return {
+                "type": "ack",
+                "serial": match.group(1).upper(),
+                "id": module_id,
+            }
+        return None
+
+    match = VERSION_RE.match(line)
+    if match:
+        address = int(match.group(1))
+        reported_id = int(match.group(3)) if match.group(3) is not None else address
+        serial_number = match.group(4)
+        return {
+            "type": "version",
+            "id": address,
+            "reported_id": reported_id,
+            "firmware": match.group(2),
+            "serial": serial_number.upper() if serial_number else "",
+            "universal": bool(serial_number),
+        }
+
+    match = SNAPSHOT_RE.match(line)
+    if match:
+        return {
+            "type": "snapshot",
+            "id": int(match.group(1)),
+            "reset_cause": int(match.group(2)),
+            "boot_count": int(match.group(3)),
+            "vcc_mv": int(match.group(4)),
+            "eeprom_ok": int(match.group(5)) == 1,
+            "current_index": int(match.group(6)),
+        }
+
+    match = HALL_RE.match(line)
+    if match:
+        return {
+            "type": "hall",
+            "id": int(match.group(1)),
+            "code": int(match.group(2)),
+            "rising_edges": int(match.group(3)),
+            "active_samples": int(match.group(4)),
+            "falling_edges": int(match.group(5)) if match.group(5) is not None else None,
+        }
+
+    match = MECHANICAL_RE.match(line)
+    if match:
+        values = match.group(2).split(":")
+        if len(values) < 6:
+            return None
+        try:
+            event = {
+                "type": "mechanical",
+                "id": int(match.group(1)),
+                "code": int(values[0]),
+                "minimum": int(values[1]),
+                "maximum": int(values[2]),
+                "spread_tenths_percent": int(values[3]),
+                "gate_active": int(values[4]),
+                "gate_span": int(values[5]),
+                "average_magnet_width": None,
+                "revolutions": [],
+            }
+            if len(values) >= 7 and values[6] != "":
+                event["average_magnet_width"] = int(values[6])
+            if len(values) >= 8 and values[7]:
+                event["revolutions"] = [
+                    int(value) for value in values[7].split(",") if value
+                ]
+            return event
+        except ValueError:
+            return None
+
+    return {"type": "other", "line": line}
+
+
+class UniversalFirmwareManager:
+    """Observe and operate Universal Firmware modules on a shared serial bus."""
+
+    ADVERTISEMENT_TTL_SECONDS = 45
+    EVENT_HISTORY_SIZE = 256
+
+    def __init__(self, get_serial, serial_lock, get_sim_mode=None):
+        self._get_serial = get_serial
+        self._serial_lock = serial_lock
+        self._get_sim_mode = get_sim_mode or (lambda: False)
+        self._state_lock = threading.RLock()
+        self._condition = threading.Condition(self._state_lock)
+        self._modules = {}
+        self._unprovisioned = {}
+        self._events = deque(maxlen=self.EVENT_HISTORY_SIZE)
+        self._event_sequence = 0
+        self._rx_buffer = b""
+        self._serial_identity = None
+        self._scan_deadline = 0.0
+        self._last_scan_at = 0.0
+        self._stop_event = threading.Event()
+        self._reader_thread = None
+
+    def start(self):
+        if self._reader_thread and self._reader_thread.is_alive():
+            return
+        self._reader_thread = threading.Thread(
+            target=self._reader_loop,
+            name="universal-firmware-reader",
+            daemon=True,
+        )
+        self._reader_thread.start()
+
+    def stop(self):
+        self._stop_event.set()
+
+    def reset(self):
+        """Clear bus-specific state, for example after changing serial ports."""
+        with self._condition:
+            self._modules.clear()
+            self._unprovisioned.clear()
+            self._events.clear()
+            self._event_sequence = 0
+            self._rx_buffer = b""
+            self._serial_identity = None
+            self._scan_deadline = 0.0
+            self._last_scan_at = 0.0
+            self._condition.notify_all()
+
+    def _reader_loop(self):
+        while not self._stop_event.is_set():
+            serial_port = self._get_serial()
+            if (
+                serial_port is None
+                or self._get_sim_mode()
+                or getattr(serial_port, "is_open", True) is False
+            ):
+                time.sleep(0.1)
+                continue
+
+            identity = id(serial_port)
+            if identity != self._serial_identity:
+                self._serial_identity = identity
+                self._rx_buffer = b""
+
+            acquired = False
+            try:
+                acquired = self._serial_lock.acquire(timeout=0.01)
+                if not acquired:
+                    time.sleep(0.01)
+                    continue
+                waiting = int(getattr(serial_port, "in_waiting", 0) or 0)
+                chunk = serial_port.read(waiting) if waiting > 0 else b""
+            except Exception as exc:
+                logging.debug("Universal Firmware serial observer: %s", exc)
+                chunk = b""
+            finally:
+                if acquired:
+                    self._serial_lock.release()
+
+            if chunk:
+                self.feed_bytes(chunk)
+            else:
+                time.sleep(0.01)
+
+    def feed_bytes(self, chunk):
+        """Feed raw serial bytes into the line parser (also useful in tests)."""
+        if not chunk:
+            return
+        self._rx_buffer += bytes(chunk)
+        if len(self._rx_buffer) > 8192 and b"\n" not in self._rx_buffer:
+            self._rx_buffer = b""
+            return
+        while b"\n" in self._rx_buffer:
+            raw_line, self._rx_buffer = self._rx_buffer.split(b"\n", 1)
+            line = raw_line.decode("ascii", errors="ignore").strip()
+            if line:
+                self.handle_line(line)
+
+    def handle_line(self, line):
+        """Record one decoded bus line and update module discovery state."""
+        event = parse_universal_line(line)
+        if event is None:
+            return None
+
+        now = time.time()
+        with self._condition:
+            event = dict(event)
+            self._event_sequence += 1
+            event["sequence"] = self._event_sequence
+            event["received_at"] = now
+            event["line"] = str(line).strip()
+            self._events.append(event)
+
+            if event["type"] == "advertisement":
+                serial_number = event["serial"]
+                entry = self._unprovisioned.get(serial_number, {
+                    "serial": serial_number,
+                    "first_seen": now,
+                })
+                entry["last_seen"] = now
+                self._unprovisioned[serial_number] = entry
+
+            elif event["type"] == "ack":
+                serial_number = event["serial"]
+                module_id = event["id"]
+                self._unprovisioned.pop(serial_number, None)
+                module = self._modules.get(module_id, {})
+                module.update({
+                    "id": module_id,
+                    "serial": serial_number,
+                    "provisioned": True,
+                    "acknowledged": True,
+                    "last_seen": now,
+                })
+                self._modules[module_id] = module
+
+            elif event["type"] == "version" and event["universal"]:
+                module_id = event["reported_id"]
+                module = self._modules.get(module_id, {})
+                module.update({
+                    "id": module_id,
+                    "serial": event["serial"],
+                    "firmware": event["firmware"],
+                    "firmware_number": parse_firmware_number(event["firmware"]),
+                    "provisioned": module_id != 255,
+                    "acknowledged": module.get("acknowledged", False),
+                    "last_seen": now,
+                })
+                if module_id == 255:
+                    serial_number = event["serial"]
+                    entry = self._unprovisioned.get(serial_number, {
+                        "serial": serial_number,
+                        "first_seen": now,
+                    })
+                    entry["last_seen"] = now
+                    self._unprovisioned[serial_number] = entry
+                else:
+                    self._unprovisioned.pop(event["serial"], None)
+                    self._modules[module_id] = module
+
+            elif event["type"] in ("snapshot", "hall", "mechanical"):
+                module = self._modules.get(event["id"])
+                if module is not None:
+                    module["last_seen"] = now
+                    diagnostics = module.setdefault("diagnostics", {})
+                    diagnostics[event["type"]] = {
+                        key: value for key, value in event.items()
+                        if key not in ("line", "sequence")
+                    }
+
+            self._condition.notify_all()
+        return event
+
+    def _connected(self):
+        serial_port = self._get_serial()
+        return bool(
+            serial_port is not None
+            and getattr(serial_port, "is_open", True) is not False
+        )
+
+    def _write(self, command):
+        if self._get_sim_mode():
+            raise UniversalFirmwareError(
+                "Switch the display to LIVE mode before using provisioning."
+            )
+        serial_port = self._get_serial()
+        if serial_port is None or getattr(serial_port, "is_open", True) is False:
+            raise UniversalFirmwareError("No serial hardware is connected.")
+        frame = command if command.endswith("\n") else command + "\n"
+        try:
+            with self._serial_lock:
+                serial_port = self._get_serial()
+                if serial_port is None:
+                    raise UniversalFirmwareError("The serial connection was closed.")
+                serial_port.write(frame.encode("ascii"))
+                serial_port.flush()
+        except UniversalFirmwareError:
+            raise
+        except Exception as exc:
+            raise UniversalFirmwareError("Serial write failed: {}".format(exc))
+
+    def _sequence(self):
+        with self._condition:
+            return self._event_sequence
+
+    def _wait_for(self, after_sequence, predicate, timeout):
+        deadline = time.monotonic() + timeout
+        with self._condition:
+            while True:
+                for event in self._events:
+                    if event["sequence"] > after_sequence and predicate(event):
+                        return dict(event)
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    return None
+                self._condition.wait(timeout=remaining)
+
+    def status(self, module_limit=45):
+        now = time.time()
+        with self._condition:
+            expired = [
+                serial_number
+                for serial_number, item in self._unprovisioned.items()
+                if now - item["last_seen"] > self.ADVERTISEMENT_TTL_SECONDS
+            ]
+            for serial_number in expired:
+                self._unprovisioned.pop(serial_number, None)
+
+            modules = []
+            for module_id in sorted(self._modules):
+                module = dict(self._modules[module_id])
+                module["online"] = now - module.get("last_seen", 0) <= 60
+                modules.append(module)
+
+            unprovisioned = []
+            for serial_number in sorted(self._unprovisioned):
+                item = dict(self._unprovisioned[serial_number])
+                item["age_seconds"] = max(0, int(now - item["last_seen"]))
+                unprovisioned.append(item)
+
+            used_ids = {module["id"] for module in modules}
+            preferred_limit = max(1, min(int(module_limit or 45), 255))
+            suggested_id = next(
+                (module_id for module_id in range(preferred_limit)
+                 if module_id not in used_ids),
+                next((module_id for module_id in range(255)
+                      if module_id not in used_ids), None),
+            )
+            return {
+                "connected": self._connected(),
+                "live": not self._get_sim_mode(),
+                "has_universal": bool(modules),
+                "modules": modules,
+                "unprovisioned": unprovisioned,
+                "suggested_id": suggested_id,
+                "scan_in_progress": time.monotonic() < self._scan_deadline,
+                "last_scan_at": self._last_scan_at,
+            }
+
+    def scan(self, maximum_id):
+        maximum_id = max(0, min(int(maximum_id), 254))
+        self._write("m*v0-{}".format(maximum_id))
+        with self._condition:
+            self._last_scan_at = time.time()
+            self._scan_deadline = (
+                time.monotonic() + 0.75 + ((maximum_id + 1) * 0.1)
+            )
+
+    @staticmethod
+    def validate_serial(serial_number):
+        serial_number = str(serial_number or "").strip().upper()
+        if not SERIAL_RE.match(serial_number):
+            raise UniversalFirmwareError(
+                "Serial number must be exactly 20 hexadecimal characters."
+            )
+        return serial_number
+
+    @staticmethod
+    def validate_id(module_id):
+        try:
+            module_id = int(module_id)
+        except (TypeError, ValueError):
+            raise UniversalFirmwareError("Module ID must be a number from 0 to 254.")
+        if module_id < 0 or module_id > 254:
+            raise UniversalFirmwareError("Module ID must be between 0 and 254.")
+        return module_id
+
+    def home_by_serial(self, serial_number):
+        serial_number = self.validate_serial(serial_number)
+        self._write("mXH{}".format(serial_number))
+
+    def home_module(self, module_id):
+        module_id = self.validate_id(module_id)
+        self._write("m{}h".format(module_id))
+
+    def provision(self, serial_number, module_id, timeout=2.0):
+        serial_number = self.validate_serial(serial_number)
+        module_id = self.validate_id(module_id)
+        with self._condition:
+            existing = self._modules.get(module_id)
+            if existing and existing.get("serial") != serial_number:
+                raise UniversalFirmwareError(
+                    "Module ID {} is already assigned to {}.".format(
+                        module_id, existing.get("serial", "another module")
+                    )
+                )
+            sequence = self._event_sequence
+
+        self._write("mXI{}:{}".format(serial_number, module_id))
+        acknowledgement = self._wait_for(
+            sequence,
+            lambda event: (
+                event["type"] == "ack"
+                and event["serial"] == serial_number
+                and event["id"] == module_id
+            ),
+            timeout,
+        )
+        if acknowledgement:
+            # Query after assignment so the inventory gains its firmware version.
+            time.sleep(0.05)
+            self._write("m{}v".format(module_id))
+        return acknowledgement is not None
+
+    def deprovision(self, module_id):
+        module_id = self.validate_id(module_id)
+        self._write("m{}R".format(module_id))
+        with self._condition:
+            self._modules.pop(module_id, None)
+
+    def deprovision_all(self):
+        self._write("m*R")
+        with self._condition:
+            self._modules.clear()
+
+    def run_diagnostic(self, module_id, kind="snapshot", revolutions=5):
+        module_id = self.validate_id(module_id)
+        kind = str(kind or "snapshot").lower()
+        if kind not in ("snapshot", "hall", "mechanical"):
+            raise UniversalFirmwareError("Unknown diagnostic test.")
+
+        with self._condition:
+            module = self._modules.get(module_id)
+            firmware_number = int((module or {}).get("firmware_number", 0))
+            if firmware_number and firmware_number < 26:
+                raise UniversalFirmwareError(
+                    "Module {} needs Universal Firmware v26 or newer for diagnostics."
+                    .format(module_id)
+                )
+            sequence = self._event_sequence
+
+        if kind == "snapshot":
+            command = "m{}Q".format(module_id)
+            timeout = 3.0
+        elif kind == "hall":
+            command = "m{}T".format(module_id)
+            timeout = 35.0
+        else:
+            try:
+                revolutions = int(revolutions)
+            except (TypeError, ValueError):
+                revolutions = 5
+            revolutions = max(5, min(revolutions, 20))
+            command = (
+                "m{}M{}".format(module_id, revolutions)
+                if firmware_number >= 29
+                else "m{}M".format(module_id)
+            )
+            timeout = 20.0 + (revolutions * 7.0)
+
+        self._write(command)
+        result = self._wait_for(
+            sequence,
+            lambda event: event["type"] == kind and event.get("id") == module_id,
+            timeout,
+        )
+        if result is None:
+            raise UniversalFirmwareError(
+                "Module {} did not answer the {} test.".format(module_id, kind)
+            )
+        return {
+            key: value for key, value in result.items()
+            if key not in ("line", "sequence")
+        }

--- a/server/hardware/universal_firmware.py
+++ b/server/hardware/universal_firmware.py
@@ -1,9 +1,13 @@
 """Universal Split-Flap Firmware discovery, provisioning, and diagnostics.
 
-The manager passively observes the shared serial bus without replacing the
-application's existing synchronous calibration transactions. Every serial read
-is protected by the same lock used by the rest of Splitflap OS, so a long
-calibration or EEPROM read keeps exclusive ownership of its response.
+Splitflap OS has one shared RS-485 receive buffer. Any operation that expects a
+reply must own the serial lock for its full write/read transaction; otherwise an
+idle observer can consume bytes intended for that operation. This manager
+follows the same rule as the existing calibration code:
+
+* the passive reader only observes unsolicited traffic while the bus is idle;
+* Universal Firmware commands that expect replies write and read under the
+  shared serial lock, then feed those bytes through the same parser.
 """
 
 from collections import deque
@@ -140,6 +144,7 @@ class UniversalFirmwareManager:
         self._get_sim_mode = get_sim_mode or (lambda: False)
         self._state_lock = threading.RLock()
         self._condition = threading.Condition(self._state_lock)
+        self._rx_lock = threading.Lock()
         self._modules = {}
         self._unprovisioned = {}
         self._events = deque(maxlen=self.EVENT_HISTORY_SIZE)
@@ -148,12 +153,14 @@ class UniversalFirmwareManager:
         self._serial_identity = None
         self._scan_deadline = 0.0
         self._last_scan_at = 0.0
+        self._last_cleanup_at = 0.0
         self._stop_event = threading.Event()
         self._reader_thread = None
 
     def start(self):
         if self._reader_thread and self._reader_thread.is_alive():
             return
+        self._stop_event.clear()
         self._reader_thread = threading.Thread(
             target=self._reader_loop,
             name="universal-firmware-reader",
@@ -161,21 +168,29 @@ class UniversalFirmwareManager:
         )
         self._reader_thread.start()
 
+    def ensure_started(self):
+        """Start passive observation on demand."""
+        self.start()
+
     def stop(self):
         self._stop_event.set()
+        if self._reader_thread and self._reader_thread.is_alive():
+            self._reader_thread.join(timeout=1.0)
 
     def reset(self):
         """Clear bus-specific state, for example after changing serial ports."""
-        with self._condition:
-            self._modules.clear()
-            self._unprovisioned.clear()
-            self._events.clear()
-            self._event_sequence = 0
+        with self._rx_lock:
             self._rx_buffer = b""
-            self._serial_identity = None
-            self._scan_deadline = 0.0
-            self._last_scan_at = 0.0
-            self._condition.notify_all()
+            with self._condition:
+                self._modules.clear()
+                self._unprovisioned.clear()
+                self._events.clear()
+                self._event_sequence = 0
+                self._serial_identity = None
+                self._scan_deadline = 0.0
+                self._last_scan_at = 0.0
+                self._last_cleanup_at = 0.0
+                self._condition.notify_all()
 
     def _reader_loop(self):
         while not self._stop_event.is_set():
@@ -191,7 +206,8 @@ class UniversalFirmwareManager:
             identity = id(serial_port)
             if identity != self._serial_identity:
                 self._serial_identity = identity
-                self._rx_buffer = b""
+                with self._rx_lock:
+                    self._rx_buffer = b""
 
             acquired = False
             try:
@@ -211,21 +227,55 @@ class UniversalFirmwareManager:
             if chunk:
                 self.feed_bytes(chunk)
             else:
+                self._cleanup_if_due()
                 time.sleep(0.01)
 
     def feed_bytes(self, chunk):
         """Feed raw serial bytes into the line parser (also useful in tests)."""
         if not chunk:
             return
-        self._rx_buffer += bytes(chunk)
-        if len(self._rx_buffer) > 8192 and b"\n" not in self._rx_buffer:
-            self._rx_buffer = b""
-            return
-        while b"\n" in self._rx_buffer:
-            raw_line, self._rx_buffer = self._rx_buffer.split(b"\n", 1)
+        with self._rx_lock:
+            self._rx_buffer += bytes(chunk)
+            if len(self._rx_buffer) > 8192 and b"\n" not in self._rx_buffer:
+                self._rx_buffer = b""
+                return
+            while b"\n" in self._rx_buffer:
+                raw_line, self._rx_buffer = self._rx_buffer.split(b"\n", 1)
+                line = raw_line.decode("ascii", errors="ignore").strip()
+                if line:
+                    self.handle_line(line)
+
+    @staticmethod
+    def _consume_lines(buffer, chunk):
+        """Return ``(remaining_buffer, decoded_lines)`` for a serial chunk."""
+        buffer += bytes(chunk or b"")
+        if len(buffer) > 8192 and b"\n" not in buffer:
+            return b"", []
+
+        lines = []
+        while b"\n" in buffer:
+            raw_line, buffer = buffer.split(b"\n", 1)
             line = raw_line.decode("ascii", errors="ignore").strip()
             if line:
-                self.handle_line(line)
+                lines.append(line)
+        return buffer, lines
+
+    def _prune_expired_unprovisioned_locked(self, now):
+        expired = [
+            serial_number
+            for serial_number, item in self._unprovisioned.items()
+            if now - item["last_seen"] > self.ADVERTISEMENT_TTL_SECONDS
+        ]
+        for serial_number in expired:
+            self._unprovisioned.pop(serial_number, None)
+
+    def _cleanup_if_due(self):
+        now = time.time()
+        with self._condition:
+            if now - self._last_cleanup_at < 5.0:
+                return
+            self._last_cleanup_at = now
+            self._prune_expired_unprovisioned_locked(now)
 
     def handle_line(self, line):
         """Record one decoded bus line and update module discovery state."""
@@ -235,6 +285,7 @@ class UniversalFirmwareManager:
 
         now = time.time()
         with self._condition:
+            self._prune_expired_unprovisioned_locked(now)
             event = dict(event)
             self._event_sequence += 1
             event["sequence"] = self._event_sequence
@@ -309,7 +360,7 @@ class UniversalFirmwareManager:
             and getattr(serial_port, "is_open", True) is not False
         )
 
-    def _write(self, command):
+    def _require_live_serial(self):
         if self._get_sim_mode():
             raise UniversalFirmwareError(
                 "Switch the display to LIVE mode before using provisioning."
@@ -317,6 +368,24 @@ class UniversalFirmwareManager:
         serial_port = self._get_serial()
         if serial_port is None or getattr(serial_port, "is_open", True) is False:
             raise UniversalFirmwareError("No serial hardware is connected.")
+        return serial_port
+
+    @staticmethod
+    def _frame(command):
+        return command if command.endswith("\n") else command + "\n"
+
+    @staticmethod
+    def _read_waiting(serial_port):
+        waiting = int(getattr(serial_port, "in_waiting", 0) or 0)
+        return serial_port.read(waiting) if waiting > 0 else b""
+
+    def _write_unlocked(self, serial_port, command):
+        frame = self._frame(command)
+        serial_port.write(frame.encode("ascii"))
+        serial_port.flush()
+
+    def _write(self, command):
+        self._require_live_serial()
         frame = command if command.endswith("\n") else command + "\n"
         try:
             with self._serial_lock:
@@ -330,33 +399,60 @@ class UniversalFirmwareManager:
         except Exception as exc:
             raise UniversalFirmwareError("Serial write failed: {}".format(exc))
 
-    def _sequence(self):
-        with self._condition:
-            return self._event_sequence
+    def _transaction(self, command, timeout, predicate=None, drain_before=True):
+        """Write a command and collect its responses while owning the bus.
 
-    def _wait_for(self, after_sequence, predicate, timeout):
-        deadline = time.monotonic() + timeout
-        with self._condition:
-            while True:
-                for event in self._events:
-                    if event["sequence"] > after_sequence and predicate(event):
-                        return dict(event)
-                remaining = deadline - time.monotonic()
-                if remaining <= 0:
-                    return None
-                self._condition.wait(timeout=remaining)
+        ``predicate`` is optional. When provided, the transaction returns the
+        first parsed event that matches it. Without a predicate, the transaction
+        reads until ``timeout`` expires and returns ``None`` after feeding all
+        complete response lines through ``handle_line``.
+        """
+        self._require_live_serial()
+        deadline = time.monotonic() + max(0.0, float(timeout or 0.0))
+        local_buffer = b""
+
+        try:
+            with self._serial_lock:
+                serial_port = self._require_live_serial()
+                if drain_before and hasattr(serial_port, "reset_input_buffer"):
+                    try:
+                        serial_port.reset_input_buffer()
+                    except Exception:
+                        pass
+
+                self._write_unlocked(serial_port, command)
+
+                while True:
+                    if self._stop_event.is_set():
+                        return None
+                    chunk = self._read_waiting(serial_port)
+                    if chunk:
+                        matched_event = None
+                        local_buffer, lines = self._consume_lines(local_buffer, chunk)
+                        for line in lines:
+                            event = self.handle_line(line)
+                            if (
+                                matched_event is None
+                                and event is not None
+                                and predicate
+                                and predicate(event)
+                            ):
+                                matched_event = dict(event)
+                        if matched_event is not None:
+                            return matched_event
+
+                    remaining = deadline - time.monotonic()
+                    if remaining <= 0:
+                        return None
+                    time.sleep(min(0.01, remaining))
+        except UniversalFirmwareError:
+            raise
+        except Exception as exc:
+            raise UniversalFirmwareError("Serial transaction failed: {}".format(exc))
 
     def status(self, module_limit=45):
         now = time.time()
         with self._condition:
-            expired = [
-                serial_number
-                for serial_number, item in self._unprovisioned.items()
-                if now - item["last_seen"] > self.ADVERTISEMENT_TTL_SECONDS
-            ]
-            for serial_number in expired:
-                self._unprovisioned.pop(serial_number, None)
-
             modules = []
             for module_id in sorted(self._modules):
                 module = dict(self._modules[module_id])
@@ -366,6 +462,8 @@ class UniversalFirmwareManager:
             unprovisioned = []
             for serial_number in sorted(self._unprovisioned):
                 item = dict(self._unprovisioned[serial_number])
+                if now - item["last_seen"] > self.ADVERTISEMENT_TTL_SECONDS:
+                    continue
                 item["age_seconds"] = max(0, int(now - item["last_seen"]))
                 unprovisioned.append(item)
 
@@ -390,12 +488,29 @@ class UniversalFirmwareManager:
 
     def scan(self, maximum_id):
         maximum_id = max(0, min(int(maximum_id), 254))
-        self._write("m*v0-{}".format(maximum_id))
+        self._require_live_serial()
+        timeout = 0.75 + ((maximum_id + 1) * 0.1)
         with self._condition:
             self._last_scan_at = time.time()
-            self._scan_deadline = (
-                time.monotonic() + 0.75 + ((maximum_id + 1) * 0.1)
-            )
+            self._scan_deadline = time.monotonic() + timeout
+
+        thread = threading.Thread(
+            target=self._scan_worker,
+            args=(maximum_id, timeout),
+            name="universal-firmware-scan",
+            daemon=True,
+        )
+        thread.start()
+
+    def _scan_worker(self, maximum_id, timeout):
+        try:
+            self._transaction("m*v0-{}".format(maximum_id), timeout=timeout)
+        except UniversalFirmwareError as exc:
+            logging.warning("Universal Firmware scan failed: %s", exc)
+        finally:
+            with self._condition:
+                self._scan_deadline = 0.0
+                self._condition.notify_all()
 
     @staticmethod
     def validate_serial(serial_number):
@@ -435,22 +550,28 @@ class UniversalFirmwareManager:
                         module_id, existing.get("serial", "another module")
                     )
                 )
-            sequence = self._event_sequence
 
-        self._write("mXI{}:{}".format(serial_number, module_id))
-        acknowledgement = self._wait_for(
-            sequence,
-            lambda event: (
+        acknowledgement = self._transaction(
+            "mXI{}:{}".format(serial_number, module_id),
+            timeout=timeout,
+            predicate=lambda event: (
                 event["type"] == "ack"
                 and event["serial"] == serial_number
                 and event["id"] == module_id
             ),
-            timeout,
         )
         if acknowledgement:
             # Query after assignment so the inventory gains its firmware version.
             time.sleep(0.05)
-            self._write("m{}v".format(module_id))
+            self._transaction(
+                "m{}v".format(module_id),
+                timeout=1.0,
+                predicate=lambda event: (
+                    event["type"] == "version"
+                    and event.get("reported_id") == module_id
+                    and event.get("universal")
+                ),
+            )
         return acknowledgement is not None
 
     def deprovision(self, module_id):
@@ -478,7 +599,6 @@ class UniversalFirmwareManager:
                     "Module {} needs Universal Firmware v26 or newer for diagnostics."
                     .format(module_id)
                 )
-            sequence = self._event_sequence
 
         if kind == "snapshot":
             command = "m{}Q".format(module_id)
@@ -499,11 +619,13 @@ class UniversalFirmwareManager:
             )
             timeout = 20.0 + (revolutions * 7.0)
 
-        self._write(command)
-        result = self._wait_for(
-            sequence,
-            lambda event: event["type"] == kind and event.get("id") == module_id,
-            timeout,
+        result = self._transaction(
+            command,
+            timeout=timeout,
+            predicate=lambda event: (
+                event["type"] == kind
+                and event.get("id") == module_id
+            ),
         )
         if result is None:
             raise UniversalFirmwareError(

--- a/server/static/app.js
+++ b/server/static/app.js
@@ -2481,7 +2481,12 @@ async function deprovisionUniversalModule(id){
 }
 
 async function deprovisionAllUniversalModules(){
-  const confirmation = prompt('This erases EVERY module ID on the bus. Type DEPROVISION ALL to continue.');
+  const confirmation = prompt(
+    'This erases EVERY module ID on the bus.\n\n' +
+    'On large displays, provision in batches of about 10–15 unprovisioned modules. ' +
+    'Too many modules advertising together can make discovery unreliable.\n\n' +
+    'Type DEPROVISION ALL to continue.'
+  );
   if(confirmation !== 'DEPROVISION ALL') return;
   try {
     await universalRequest('/universal/deprovision', {

--- a/server/static/app.js
+++ b/server/static/app.js
@@ -79,6 +79,12 @@ let selectedCharIndex = 0;
 let playlist = [];
 let editingIndex = null;
 let currentActiveApp = null;
+let universalProvisioning = {
+  initialized: false,
+  manualOpen: null,
+  status: null,
+  diagnosticModule: null,
+};
 
 let lastFocusedInput = null;
 let lastCursorPos = 0;
@@ -245,6 +251,10 @@ async function toggleSimMode() {
     body: JSON.stringify({enabled: simMode})
   });
   showToast(simMode ? 'Simulation mode — hardware output disabled' : 'Live mode — sending to hardware');
+  if(universalProvisioning.initialized){
+    const status = await refreshUniversalProvisioning();
+    if(!simMode && status?.connected) scanUniversalModules(true);
+  }
 }
 
 function initLiveGrids(rows, cols) {
@@ -409,7 +419,10 @@ function openMenuPage(name){
   document.getElementById('bottomTabs').style.display='none';
   document.querySelectorAll('.page').forEach(p=>p.classList.remove('active'));
   document.getElementById('page-'+name).classList.add('active');
-  if(name==='calibration') loadSettingsData();
+  if(name==='calibration'){
+    loadSettingsData();
+    initUniversalProvisioning();
+  }
   if(name==='settings') loadSettingsData();
   if(name==='library') loadAppLibrary();
   if(name==='schedules') loadSchedules();
@@ -2137,6 +2150,10 @@ function applySerialPort(){
         const ctSel = document.getElementById('connectionType');
         if(ctSel){ ctSel.value = 'serial'; onConnectionTypeChange('serial'); }
         showToast(data.sim_mode ? 'Port saved but could not open — simulation mode' : 'Serial port connected');
+        universalProvisioning.manualOpen = null;
+        refreshUniversalProvisioning().then(s=>{
+          if(s && s.connected && s.live) scanUniversalModules(true);
+        });
       } else {
         status.textContent = data.message||'Error';
         status.style.color = '#f44';
@@ -2198,6 +2215,10 @@ function applyGatewayConnection(){
         showToast(data.message || 'Gateway settings saved');
         // Clear the password field; it's persisted server-side now.
         document.getElementById('gatewayPassword').value = '';
+        universalProvisioning.manualOpen = null;
+        refreshUniversalProvisioning().then(s=>{
+          if(s && s.connected && s.live) scanUniversalModules(true);
+        });
       } else {
         status.textContent = data.message || 'Error';
         status.style.color = '#f44';
@@ -2207,6 +2228,394 @@ function applyGatewayConnection(){
       status.textContent = 'Request failed';
       status.style.color = '#f44';
     });
+}
+
+// --- Universal Firmware provisioning ---
+function escapeProvision(value){
+  return String(value ?? '').replace(/[&<>"']/g, ch=>({
+    '&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'
+  })[ch]);
+}
+
+async function universalRequest(url, options={}){
+  const response = await fetch(url, options);
+  let data = {};
+  try { data = await response.json(); } catch(e) {}
+  if(!response.ok){
+    throw new Error(data.message || `Request failed (${response.status})`);
+  }
+  return {response, data};
+}
+
+function setProvisionCardOpen(open, manual=false){
+  const card = document.getElementById('provisionCard');
+  const header = document.getElementById('provisionCardHeader');
+  if(!card || !header) return;
+  card.classList.toggle('collapsed', !open);
+  header.setAttribute('aria-expanded', open ? 'true' : 'false');
+  if(manual) universalProvisioning.manualOpen = !!open;
+}
+
+function toggleProvisionCard(){
+  const card = document.getElementById('provisionCard');
+  if(card) setProvisionCardOpen(card.classList.contains('collapsed'), true);
+}
+
+async function initUniversalProvisioning(){
+  if(!universalProvisioning.initialized){
+    universalProvisioning.initialized = true;
+    setInterval(()=>{
+      const page = document.getElementById('page-calibration');
+      if(page && page.classList.contains('active')) refreshUniversalProvisioning();
+    }, 2500);
+  }
+  const status = await refreshUniversalProvisioning();
+  if(status && status.connected && status.live && !status.last_scan_at){
+    scanUniversalModules(true);
+  }
+}
+
+async function refreshUniversalProvisioning(){
+  try {
+    const {data} = await universalRequest('/universal/status');
+    universalProvisioning.status = data;
+    renderUniversalProvisioning(data);
+    return data;
+  } catch(e) {
+    const notice = document.getElementById('provisionConnectionNotice');
+    if(notice){
+      notice.className = 'provision-notice visible error';
+      notice.textContent = `Provisioning status unavailable: ${e.message}`;
+    }
+    return null;
+  }
+}
+
+function renderUniversalProvisioning(data){
+  const card = document.getElementById('provisionCard');
+  if(!card) return;
+
+  const modules = data.modules || [];
+  const unprovisioned = data.unprovisioned || [];
+  const active = modules.length > 0 || unprovisioned.length > 0;
+  card.classList.toggle('has-unprovisioned', unprovisioned.length > 0);
+  if(universalProvisioning.manualOpen === null) setProvisionCardOpen(active, false);
+
+  const subtitle = document.getElementById('provisionCardSubtitle');
+  if(!data.connected) subtitle.textContent = 'No serial hardware connected';
+  else if(!data.live) subtitle.textContent = 'Switch to LIVE mode to scan and provision';
+  else if(unprovisioned.length) subtitle.textContent = `${unprovisioned.length} module${unprovisioned.length===1?'':'s'} waiting for an ID`;
+  else if(modules.length) subtitle.textContent = `${modules.length} Universal Firmware module${modules.length===1?'':'s'} detected`;
+  else if(data.scan_in_progress) subtitle.textContent = 'Scanning the configured module range…';
+  else subtitle.textContent = 'Universal Firmware module setup';
+
+  const universalBadge = document.getElementById('provisionUniversalBadge');
+  universalBadge.style.display = modules.length ? 'inline-flex' : 'none';
+  universalBadge.textContent = `${modules.length} universal`;
+  const unassignedBadge = document.getElementById('provisionUnassignedBadge');
+  unassignedBadge.style.display = unprovisioned.length ? 'inline-flex' : 'none';
+  unassignedBadge.textContent = `${unprovisioned.length} unassigned`;
+
+  const notice = document.getElementById('provisionConnectionNotice');
+  if(!data.connected){
+    notice.className = 'provision-notice visible error';
+    notice.textContent = 'Connect the RS-485 serial adapter in Settings before provisioning modules.';
+  } else if(!data.live){
+    notice.className = 'provision-notice visible warn';
+    notice.textContent = 'Provisioning is read-only while Splitflap OS is in simulation mode. Switch the top-bar toggle to LIVE.';
+  } else {
+    notice.className = 'provision-notice';
+    notice.textContent = '';
+  }
+
+  const scanBtn = document.getElementById('provisionScanBtn');
+  if(scanBtn){
+    scanBtn.disabled = !data.connected || !data.live || data.scan_in_progress;
+    scanBtn.innerHTML = data.scan_in_progress
+      ? '<span class="provision-spinner" style="width:13px;height:13px"></span> Scanning'
+      : '<i data-lucide="scan-search" style="width:14px;height:14px"></i> Scan';
+  }
+
+  renderUnprovisionedModules(unprovisioned, modules, data.suggested_id);
+  renderUniversalModules(modules);
+  if(typeof lucide!=='undefined') lucide.createIcons();
+}
+
+function renderUnprovisionedModules(items, modules, firstSuggestedId){
+  const list = document.getElementById('unprovisionedModules');
+  if(!list) return;
+  if(!items.length){
+    list.innerHTML = '<div class="provision-empty">No recent advertisements. Newly flashed modules may take up to 15 seconds to appear.</div>';
+    return;
+  }
+
+  const used = new Set((modules || []).map(module=>Number(module.id)));
+  let nextId = Number.isInteger(firstSuggestedId) ? firstSuggestedId : 0;
+  list.innerHTML = items.map(item=>{
+    while(nextId <= 254 && used.has(nextId)) nextId++;
+    const suggested = nextId <= 254 ? nextId : '';
+    if(suggested !== ''){ used.add(suggested); nextId++; }
+    const serial = escapeProvision(item.serial);
+    return `<div class="provision-unassigned">
+      <div>
+        <div class="provision-serial">${serial}</div>
+        <div style="color:#786a50;font-size:.68rem;margin-top:2px">advertised ${item.age_seconds || 0}s ago</div>
+      </div>
+      <button class="btn btn-secondary btn-sm" onclick="identifyUniversalModule('${serial}')" title="Home this module so you can locate it">
+        <i data-lucide="locate-fixed" style="width:14px;height:14px"></i> Identify
+      </button>
+      <input class="provision-id-input" id="provision-id-${serial}" type="number" min="0" max="254"
+             value="${suggested}" aria-label="New module ID for ${serial}">
+      <button class="btn btn-success btn-sm" onclick="assignUniversalModule('${serial}')">Assign ID</button>
+    </div>`;
+  }).join('');
+}
+
+function renderUniversalModules(modules){
+  const grid = document.getElementById('universalModules');
+  if(!grid) return;
+  if(!modules.length){
+    grid.innerHTML = '<div class="provision-empty">No Universal Firmware modules detected yet. Scan to query the configured display range.</div>';
+    return;
+  }
+  grid.innerHTML = modules.map(module=>{
+    const id = Number(module.id);
+    const firmware = escapeProvision(module.firmware || '');
+    const firmwareLabel = firmware ? `v${firmware.replace(/^v/i,'')}` : 'detecting';
+    const serial = escapeProvision(module.serial || 'serial pending');
+    const diagnosticButton = Number(module.firmware_number || 0) >= 26
+      ? `<button class="btn btn-secondary btn-sm" onclick="openUniversalDiagnostics(${id})" title="Run Universal Firmware health tests">
+           <i data-lucide="stethoscope" style="width:13px;height:13px"></i> Diagnose
+         </button>`
+      : '';
+    return `<article class="provision-module${module.online===false?' offline':''}">
+      <div class="provision-module-top">
+        <div class="provision-module-id">Module <strong>${id.toString().padStart(2,'0')}</strong></div>
+        <span class="provision-fw">${firmwareLabel}</span>
+      </div>
+      <div class="provision-module-sn">${serial}</div>
+      <div class="provision-module-actions">
+        <button class="btn btn-secondary btn-sm" onclick="homeUniversalModule(${id})">
+          <i data-lucide="home" style="width:13px;height:13px"></i> Home
+        </button>
+        ${diagnosticButton}
+        <button class="btn-del" onclick="deprovisionUniversalModule(${id})" title="Erase this module's ID">
+          <i data-lucide="unlink" style="width:13px;height:13px"></i> De-provision
+        </button>
+      </div>
+    </article>`;
+  }).join('');
+}
+
+async function scanUniversalModules(silent=false){
+  const btn = document.getElementById('provisionScanBtn');
+  if(btn) btn.disabled = true;
+  try {
+    await universalRequest('/universal/scan', {method:'POST'});
+    if(!silent) showToast('Scanning for Universal Firmware modules');
+    setTimeout(refreshUniversalProvisioning, 400);
+  } catch(e) {
+    if(!silent) showToast(e.message, 'error');
+  } finally {
+    setTimeout(refreshUniversalProvisioning, 900);
+  }
+}
+
+async function identifyUniversalModule(serial){
+  try {
+    await universalRequest('/universal/home', {
+      method:'POST', headers:{'Content-Type':'application/json'},
+      body:JSON.stringify({serial})
+    });
+    showToast('Identify sent — watch for the module that homes');
+  } catch(e) { showToast(e.message, 'error'); }
+}
+
+async function assignUniversalModule(serial){
+  const input = document.getElementById(`provision-id-${serial}`);
+  const id = input ? Number(input.value) : NaN;
+  if(!Number.isInteger(id) || id < 0 || id > 254){
+    showToast('Choose a module ID from 0 to 254', 'warn');
+    if(input) input.focus();
+    return;
+  }
+  if(!confirm(`Assign module ID ${id} to serial ${serial}?`)) return;
+  if(input) input.disabled = true;
+  try {
+    const {data} = await universalRequest('/universal/provision', {
+      method:'POST', headers:{'Content-Type':'application/json'},
+      body:JSON.stringify({serial, id})
+    });
+    showToast(
+      data.acknowledged ? `Module acknowledged ID ${id}` : data.message,
+      data.acknowledged ? 'success' : 'warn'
+    );
+    await refreshUniversalProvisioning();
+  } catch(e) {
+    showToast(e.message, 'error');
+  } finally {
+    if(input) input.disabled = false;
+  }
+}
+
+async function homeUniversalModule(id){
+  try {
+    await universalRequest('/universal/home', {
+      method:'POST', headers:{'Content-Type':'application/json'},
+      body:JSON.stringify({id})
+    });
+    showToast(`Homing module ${String(id).padStart(2,'0')}`);
+  } catch(e) { showToast(e.message, 'error'); }
+}
+
+async function deprovisionUniversalModule(id){
+  if(!confirm(`De-provision module ${id}? Its calibration stays intact, but its bus ID will be erased.`)) return;
+  try {
+    await universalRequest('/universal/deprovision', {
+      method:'POST', headers:{'Content-Type':'application/json'},
+      body:JSON.stringify({id})
+    });
+    showToast(`Module ${id} is returning to provisioning mode`, 'warn');
+    await refreshUniversalProvisioning();
+  } catch(e) { showToast(e.message, 'error'); }
+}
+
+async function deprovisionAllUniversalModules(){
+  const confirmation = prompt('This erases EVERY module ID on the bus. Type DEPROVISION ALL to continue.');
+  if(confirmation !== 'DEPROVISION ALL') return;
+  try {
+    await universalRequest('/universal/deprovision', {
+      method:'POST', headers:{'Content-Type':'application/json'},
+      body:JSON.stringify({all:true})
+    });
+    showToast('All modules are returning to provisioning mode', 'warn');
+    await refreshUniversalProvisioning();
+  } catch(e) { showToast(e.message, 'error'); }
+}
+
+function openUniversalDiagnostics(id){
+  const module = (universalProvisioning.status?.modules || []).find(item=>Number(item.id)===Number(id));
+  if(!module) return;
+  universalProvisioning.diagnosticModule = module;
+  document.getElementById('universalDiagnosticsTitle').textContent = `Module ${String(id).padStart(2,'0')} Diagnostics`;
+  document.getElementById('universalDiagnosticsSubtitle').textContent =
+    `${module.serial || 'serial unknown'} · firmware v${String(module.firmware || '?').replace(/^v/i,'')}`;
+  document.getElementById('universalDiagnosticsModal').style.display = 'flex';
+  if(typeof lucide!=='undefined') lucide.createIcons();
+  runUniversalDiagnostic('snapshot');
+}
+
+function closeUniversalDiagnostics(){
+  document.getElementById('universalDiagnosticsModal').style.display = 'none';
+  universalProvisioning.diagnosticModule = null;
+}
+
+function universalDiagnosticRows(rows){
+  return `<table class="provision-diagnostic-table">${rows.map(row=>
+    `<tr><th>${escapeProvision(row[0])}</th><td>${escapeProvision(row[1])}</td></tr>`
+  ).join('')}</table>`;
+}
+
+function universalResetCauseText(value){
+  const causes = [];
+  if(value & 0x01) causes.push('power-on');
+  if(value & 0x02) causes.push('brown-out');
+  if(value & 0x04) causes.push('external');
+  if(value & 0x08) causes.push('watchdog');
+  if(value & 0x10) causes.push('software');
+  return causes.length ? causes.join(', ') : 'none reported';
+}
+
+function renderUniversalDiagnostic(result){
+  const body = document.getElementById('universalDiagnosticsBody');
+  if(result.type === 'snapshot'){
+    const resetWarning = !!(result.reset_cause & 0x0a);
+    const voltageWarning = result.vcc_mv > 0 &&
+      (result.vcc_mv >= 4000 ? result.vcc_mv < 4500 : result.vcc_mv < 3000);
+    const bad = !result.eeprom_ok;
+    const warn = resetWarning || voltageWarning;
+    const verdict = bad ? 'EEPROM verification failed'
+      : warn ? 'Health snapshot has warnings'
+      : 'Health snapshot looks normal';
+    const currentIndex = result.current_index === -1 ? 'unknown — home required'
+      : result.current_index === -2 ? 'released' : result.current_index;
+    body.innerHTML = `<div class="provision-diagnostic-result">
+      <div class="provision-diagnostic-verdict ${bad?'bad':warn?'warn':'good'}">${verdict}</div>
+      ${universalDiagnosticRows([
+        ['Last reset', `${universalResetCauseText(result.reset_cause)} (0x${Number(result.reset_cause).toString(16).padStart(2,'0')})`],
+        ['Boot count', `${result.boot_count} (wraps at 255)`],
+        ['Supply voltage', result.vcc_mv ? `${(result.vcc_mv/1000).toFixed(2)} V${voltageWarning?' — low':''}` : 'not available'],
+        ['EEPROM verify', result.eeprom_ok ? 'passed' : 'FAILED'],
+        ['Current flap', currentIndex],
+      ])}
+    </div>`;
+  } else if(result.type === 'hall'){
+    const messages = {
+      0:'One clean home region detected.',
+      1:'Sensor stayed active for the full revolution.',
+      2:'Sensor never detected the home magnet.',
+      3:'Multiple active regions were detected.',
+      4:'Sensor polarity appears inverted.',
+    };
+    const edgeWarning = result.code === 0 &&
+      (result.rising_edges !== 1 || (result.falling_edges !== null && result.falling_edges !== 1));
+    const good = result.code === 0 && !edgeWarning;
+    body.innerHTML = `<div class="provision-diagnostic-result">
+      <div class="provision-diagnostic-verdict ${good?'good':result.code===3||result.code===4||edgeWarning?'warn':'bad'}">
+        ${escapeProvision(messages[result.code] || `Unknown Hall result code ${result.code}`)}
+      </div>
+      ${universalDiagnosticRows([
+        ['Rising edges', result.rising_edges],
+        ['Falling edges', result.falling_edges === null ? 'not reported by this firmware' : result.falling_edges],
+        ['Active samples', result.active_samples],
+      ])}
+    </div>`;
+  } else if(result.type === 'mechanical'){
+    const messages = {
+      0:'Motor motion is consistent.',
+      1:'Revolution counts are inconsistent — check drag, power, and the driver.',
+      2:'No complete motion was detected — check the Hall result, motor wiring, and jams.',
+    };
+    const severity = result.code === 0 ? 'good' : result.code === 1 ? 'warn' : 'bad';
+    body.innerHTML = `<div class="provision-diagnostic-result">
+      <div class="provision-diagnostic-verdict ${severity}">
+        ${escapeProvision(messages[result.code] || `Unknown mechanical result code ${result.code}`)}
+      </div>
+      ${universalDiagnosticRows([
+        ['Steps / revolution', result.minimum || result.maximum ? `${result.minimum} … ${result.maximum}` : 'not measured'],
+        ['Spread', `${(result.spread_tenths_percent/10).toFixed(1)}%`],
+        ['Motion gate', `${result.gate_active} active / ${result.gate_span} steps`],
+        ['Average magnet width', result.average_magnet_width ?? 'not reported by this firmware'],
+        ['Per-revolution counts', (result.revolutions || []).length ? result.revolutions.join(', ') : 'not reported by this firmware'],
+      ])}
+    </div>`;
+  }
+}
+
+async function runUniversalDiagnostic(kind){
+  const module = universalProvisioning.diagnosticModule;
+  if(!module) return;
+  if((kind === 'hall' || kind === 'mechanical') &&
+     !confirm(`${kind === 'hall' ? 'The Hall test' : 'The mechanical test'} will spin module ${module.id}. Continue?`)) return;
+
+  const body = document.getElementById('universalDiagnosticsBody');
+  const label = kind === 'snapshot' ? 'Reading health snapshot…'
+    : kind === 'hall' ? 'Testing the Hall sensor — the reel will move…'
+    : 'Testing motor consistency across five revolutions…';
+  body.innerHTML = `<div class="provision-diagnostic-loading"><span class="provision-spinner"></span>${label}</div>`;
+  const buttons = document.querySelectorAll('#universalDiagnosticsModal .provision-diagnostic-actions button');
+  buttons.forEach(button=>button.disabled=true);
+  try {
+    const {data} = await universalRequest('/universal/diagnose', {
+      method:'POST', headers:{'Content-Type':'application/json'},
+      body:JSON.stringify({id:module.id, kind, revolutions:5})
+    });
+    renderUniversalDiagnostic(data.result);
+  } catch(e) {
+    body.innerHTML = `<div class="provision-notice visible error">${escapeProvision(e.message)}</div>`;
+  } finally {
+    buttons.forEach(button=>button.disabled=false);
+  }
 }
 
 function selectModule(id){

--- a/server/static/app.js
+++ b/server/static/app.js
@@ -80,7 +80,7 @@ let playlist = [];
 let editingIndex = null;
 let currentActiveApp = null;
 let universalProvisioning = {
-  initialized: false,
+  pollIntervalId: null,
   manualOpen: null,
   status: null,
   diagnosticModule: null,
@@ -251,7 +251,7 @@ async function toggleSimMode() {
     body: JSON.stringify({enabled: simMode})
   });
   showToast(simMode ? 'Simulation mode — hardware output disabled' : 'Live mode — sending to hardware');
-  if(universalProvisioning.initialized){
+  if(universalProvisioning.pollIntervalId !== null){
     const status = await refreshUniversalProvisioning();
     if(!simMode && status?.connected) scanUniversalModules(true);
   }
@@ -387,6 +387,7 @@ setInterval(()=>{
 //  TAB SWITCHING
 // ============================================================
 function switchTab(name){
+  if(name !== 'calibration') stopUniversalProvisioningPolling();
   document.querySelectorAll('.bottom-tab').forEach(b=>b.classList.remove('active'));
   document.querySelectorAll('.page').forEach(p=>p.classList.remove('active'));
   document.getElementById('tab-'+name).classList.add('active');
@@ -414,6 +415,7 @@ function openMenuPage(name){
   // Close hamburger if open (don't toggle — callers outside the drawer would open it)
   const drawer = document.getElementById('hamburgerDrawer');
   if(drawer && drawer.classList.contains('open')) toggleHamburger();
+  if(name !== 'calibration') stopUniversalProvisioningPolling();
   const active = document.querySelector('.bottom-tab.active');
   if(active) _prevTab = active.id.replace('tab-','');
   document.getElementById('bottomTabs').style.display='none';
@@ -431,12 +433,14 @@ function openMenuPage(name){
 }
 
 function closeMenuPage(){
+  stopUniversalProvisioningPolling();
   document.querySelectorAll('.page').forEach(p=>p.classList.remove('active'));
   document.getElementById('page-'+_prevTab).classList.add('active');
   document.getElementById('bottomTabs').style.display='flex';
 }
 
 function openAppLibrary(){
+  stopUniversalProvisioningPolling();
   const active = document.querySelector('.bottom-tab.active');
   if(active) _prevTab = active.id.replace('tab-','');
   document.getElementById('bottomTabs').style.display='none';
@@ -2261,14 +2265,22 @@ function toggleProvisionCard(){
   if(card) setProvisionCardOpen(card.classList.contains('collapsed'), true);
 }
 
+function startUniversalProvisioningPolling(){
+  if(universalProvisioning.pollIntervalId !== null) return;
+  universalProvisioning.pollIntervalId = setInterval(()=>{
+    const page = document.getElementById('page-calibration');
+    if(page && page.classList.contains('active')) refreshUniversalProvisioning();
+  }, 2500);
+}
+
+function stopUniversalProvisioningPolling(){
+  if(universalProvisioning.pollIntervalId === null) return;
+  clearInterval(universalProvisioning.pollIntervalId);
+  universalProvisioning.pollIntervalId = null;
+}
+
 async function initUniversalProvisioning(){
-  if(!universalProvisioning.initialized){
-    universalProvisioning.initialized = true;
-    setInterval(()=>{
-      const page = document.getElementById('page-calibration');
-      if(page && page.classList.contains('active')) refreshUniversalProvisioning();
-    }, 2500);
-  }
+  startUniversalProvisioningPolling();
   const status = await refreshUniversalProvisioning();
   if(status && status.connected && status.live && !status.last_scan_at){
     scanUniversalModules(true);

--- a/server/static/styles.css
+++ b/server/static/styles.css
@@ -210,6 +210,8 @@ h3{margin-top:0;color:var(--text)}
 .provision-danger{margin-top:14px;border-top:1px solid #333;padding-top:12px;color:#888;font-size:.78rem}
 .provision-danger summary{cursor:pointer;color:#9a7777;font-weight:650}
 .provision-danger p{line-height:1.5;max-width:620px}
+.provision-danger-warning{padding:9px 11px;border:1px solid #704c0b;border-radius:7px;background:#302109;color:#e2b96d}
+.provision-danger-warning strong{color:#ffd27c}
 .provision-danger .btn-del{font-size:.8rem}
 .provision-diagnostics-modal{max-width:580px}
 .provision-modal-header{display:flex;align-items:flex-start;justify-content:space-between;gap:12px;margin-bottom:14px}

--- a/server/static/styles.css
+++ b/server/static/styles.css
@@ -165,6 +165,73 @@ h3{margin-top:0;color:var(--text)}
 .span2{grid-column:span 2}
 .field-label{display:block;margin-bottom:5px;color:#888;font-size:.85rem}
 
+/* ── UNIVERSAL FIRMWARE PROVISIONING ── */
+.provision-card{padding:0;border-left:5px solid var(--green);overflow:hidden;transition:border-color .2s}
+.provision-card.has-unprovisioned{border-left-color:var(--orange)}
+.provision-card-header{width:100%;display:flex;align-items:center;justify-content:space-between;gap:14px;padding:17px 18px;background:none;border:none;color:var(--text);cursor:pointer;text-align:left}
+.provision-card-header:hover{background:#242424}
+.provision-card-title{display:flex;align-items:center;gap:11px;min-width:0}
+.provision-card-icon{width:34px;height:34px;display:flex;align-items:center;justify-content:center;border-radius:8px;background:#173822;color:#6ee7a0;flex:0 0 auto}
+.provision-card-name{display:block;font-size:1.05rem;font-weight:750;color:#fff}
+.provision-card-subtitle{display:block;color:#888;font-size:.78rem;margin-top:2px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;max-width:430px}
+.provision-card-meta{display:flex;align-items:center;justify-content:flex-end;gap:7px;flex:0 0 auto}
+.provision-badge{display:inline-flex;align-items:center;min-height:23px;padding:3px 8px;border-radius:999px;background:#173822;border:1px solid #28603b;color:#82e7a7;font-size:.72rem;font-weight:700;white-space:nowrap}
+.provision-badge.attention{background:#3b260b;border-color:#794e0b;color:#ffbd58}
+.provision-chevron{color:#777;transition:transform .2s}
+.provision-card.collapsed .provision-chevron{transform:rotate(-90deg)}
+.provision-card-body{padding:0 18px 18px}
+.provision-card.collapsed .provision-card-body{display:none}
+.provision-intro{color:#aaa;font-size:.86rem;line-height:1.55;margin:0 0 14px}
+.provision-notice{display:none;padding:10px 12px;border-radius:8px;margin-bottom:14px;font-size:.82rem;line-height:1.45}
+.provision-notice.visible{display:block}
+.provision-notice.warn{background:#302109;border:1px solid #704c0b;color:#f7c66e}
+.provision-notice.error{background:#311414;border:1px solid #6c2929;color:#ff9b9b}
+.provision-section{background:#191919;border:1px solid #343434;border-radius:10px;padding:14px;margin-top:12px}
+.provision-section-heading{display:flex;align-items:flex-start;justify-content:space-between;gap:12px;margin-bottom:11px}
+.provision-section-heading h4{margin:0 0 3px;color:#eee;font-size:.92rem}
+.provision-section-heading p{margin:0;color:#777;font-size:.76rem;line-height:1.45}
+.provision-list{display:flex;flex-direction:column;gap:8px}
+.provision-empty{color:#666;font-size:.82rem;padding:9px 2px}
+.provision-unassigned{display:grid;grid-template-columns:minmax(190px,1fr) auto minmax(74px,100px) auto;gap:8px;align-items:center;padding:10px;background:#211b12;border:1px solid #604415;border-radius:8px}
+.provision-serial{font-family:'Courier New',monospace;font-size:.79rem;color:#f5bf5c;word-break:break-all}
+.provision-id-input{width:100%;min-width:0;background:#0e0e0e;color:#fff;border:1px solid #555;border-radius:6px;padding:7px 8px;font-family:monospace;font-size:.86rem}
+.provision-id-input:focus{outline:none;border-color:var(--accent)}
+.provision-module-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(205px,1fr));gap:8px}
+.provision-module{position:relative;background:#121a15;border:1px solid #31563c;border-radius:9px;padding:12px;min-width:0}
+.provision-module.offline{background:#191919;border-color:#3a3a3a}
+.provision-module-top{display:flex;align-items:flex-start;justify-content:space-between;gap:8px;margin-bottom:7px}
+.provision-module-id{font-size:1rem;font-weight:750;color:#fff}
+.provision-module-id strong{color:#7ce4a2}
+.provision-fw{font-family:monospace;font-size:.72rem;color:#8ee9ae;background:#173822;border:1px solid #28603b;padding:2px 6px;border-radius:999px}
+.provision-module-sn{font-family:'Courier New',monospace;font-size:.7rem;color:#888;word-break:break-all}
+.provision-module-actions{display:flex;gap:6px;flex-wrap:wrap;margin-top:10px}
+.provision-module-actions .btn,.provision-module-actions .btn-del{padding:6px 9px;font-size:.75rem;display:inline-flex;align-items:center;gap:4px}
+.provision-module-actions .btn-del{margin-left:auto;background:#572329;color:#ffb2b8}
+.provision-danger{margin-top:14px;border-top:1px solid #333;padding-top:12px;color:#888;font-size:.78rem}
+.provision-danger summary{cursor:pointer;color:#9a7777;font-weight:650}
+.provision-danger p{line-height:1.5;max-width:620px}
+.provision-danger .btn-del{font-size:.8rem}
+.provision-diagnostics-modal{max-width:580px}
+.provision-modal-header{display:flex;align-items:flex-start;justify-content:space-between;gap:12px;margin-bottom:14px}
+.provision-modal-header h3{margin:0 0 3px;color:var(--accent)}
+.provision-modal-header #universalDiagnosticsSubtitle{color:#777;font-family:monospace;font-size:.76rem}
+.provision-modal-close{background:none;border:none;color:#888;font-size:1.6rem;line-height:1;cursor:pointer;padding:0 4px}
+.provision-modal-close:hover{color:#fff}
+.provision-diagnostic-actions{display:flex;gap:7px;flex-wrap:wrap;margin-top:14px}
+.provision-diagnostic-warning{color:#766b57;font-size:.74rem;line-height:1.45;margin:10px 0 0}
+.provision-diagnostic-loading{display:flex;align-items:center;gap:9px;color:#aaa;padding:14px 2px}
+.provision-spinner{width:18px;height:18px;border:2px solid #444;border-top-color:var(--accent);border-radius:50%;animation:spin 1s linear infinite}
+.provision-diagnostic-result{background:#111;border:1px solid #333;border-radius:9px;overflow:hidden}
+.provision-diagnostic-verdict{padding:11px 13px;font-weight:700;font-size:.86rem;border-bottom:1px solid #333}
+.provision-diagnostic-verdict.good{background:#122a1b;color:#83e5a7}
+.provision-diagnostic-verdict.warn{background:#302109;color:#f7c66e}
+.provision-diagnostic-verdict.bad{background:#311414;color:#ff9b9b}
+.provision-diagnostic-table{width:100%;border-collapse:collapse;font-size:.8rem}
+.provision-diagnostic-table th,.provision-diagnostic-table td{padding:8px 11px;border-bottom:1px solid #292929;text-align:left;vertical-align:top}
+.provision-diagnostic-table tr:last-child th,.provision-diagnostic-table tr:last-child td{border-bottom:none}
+.provision-diagnostic-table th{width:42%;color:#777;font-weight:500}
+.provision-diagnostic-table td{color:#ddd;font-family:monospace;word-break:break-word}
+
 /* ── TOGGLE ── */
 .switch{position:relative;display:inline-block;width:40px;height:20px}
 .switch input{opacity:0;width:0;height:0}
@@ -345,6 +412,14 @@ input:checked+.slider:before{transform:translateX(20px)}
   .at-grid{gap:2px}
   .at-cell{font-size:.7rem}
   .at-char-display{font-size:2rem;padding:6px 14px}
+  .provision-card-header{padding:14px 13px}
+  .provision-card-body{padding:0 13px 14px}
+  .provision-card-subtitle{max-width:210px}
+  .provision-card-meta .provision-badge{display:none!important}
+  .provision-unassigned{grid-template-columns:1fr 78px auto}
+  .provision-unassigned > div:first-child{grid-column:1/-1}
+  .provision-unassigned .provision-id-input{width:78px}
+  .provision-module-grid{grid-template-columns:1fr}
 }
 @media(max-width:380px){
   .apps-grid{grid-template-columns:repeat(2,1fr)}

--- a/server/templates/index.html
+++ b/server/templates/index.html
@@ -184,6 +184,66 @@
   <!-- ══════════ CALIBRATION PAGE ══════════ -->
   <div id="page-calibration" class="page">
     <button class="hamburger-back" onclick="closeMenuPage()"><i data-lucide="arrow-left" style="width:14px;height:14px"></i> Back</button>
+    <div class="config-section provision-card collapsed" id="provisionCard">
+      <button class="provision-card-header" id="provisionCardHeader" type="button"
+              onclick="toggleProvisionCard()" aria-expanded="false" aria-controls="provisionCardBody">
+        <span class="provision-card-title">
+          <span class="provision-card-icon"><i data-lucide="cpu" style="width:18px;height:18px"></i></span>
+          <span>
+            <span class="provision-card-name">Provision</span>
+            <span class="provision-card-subtitle" id="provisionCardSubtitle">Universal Firmware module setup</span>
+          </span>
+        </span>
+        <span class="provision-card-meta">
+          <span class="provision-badge" id="provisionUniversalBadge" style="display:none"></span>
+          <span class="provision-badge attention" id="provisionUnassignedBadge" style="display:none"></span>
+          <i data-lucide="chevron-down" class="provision-chevron" style="width:18px;height:18px"></i>
+        </span>
+      </button>
+
+      <div class="provision-card-body" id="provisionCardBody">
+        <p class="provision-intro">
+          Discover modules running Universal Firmware, identify new modules by moving them,
+          assign bus IDs, and check module health without leaving calibration.
+        </p>
+
+        <div id="provisionConnectionNotice" class="provision-notice"></div>
+
+        <section class="provision-section">
+          <div class="provision-section-heading">
+            <div>
+              <h4>Unprovisioned Modules</h4>
+              <p>New modules advertise every 10–15 seconds. Identify the physical module, then assign its ID.</p>
+            </div>
+          </div>
+          <div id="unprovisionedModules" class="provision-list">
+            <div class="provision-empty">Listening for advertisements…</div>
+          </div>
+        </section>
+
+        <section class="provision-section">
+          <div class="provision-section-heading">
+            <div>
+              <h4>Universal Modules</h4>
+              <p>Provisioned modules discovered in the configured display grid.</p>
+            </div>
+            <button class="btn btn-secondary btn-sm" id="provisionScanBtn" onclick="scanUniversalModules()">
+              <i data-lucide="scan-search" style="width:14px;height:14px"></i> Scan
+            </button>
+          </div>
+          <div id="universalModules" class="provision-module-grid">
+            <div class="provision-empty">No Universal Firmware modules detected yet.</div>
+          </div>
+        </section>
+
+        <details class="provision-danger">
+          <summary>Advanced: de-provision all modules</summary>
+          <p>This erases every module ID on the bus. Calibration data is preserved, but every module must be assigned again.</p>
+          <button class="btn-del" onclick="deprovisionAllUniversalModules()">De-provision All Modules</button>
+        </details>
+      </div>
+    </div>
+
     <div class="config-section" style="border-left:5px solid var(--accent)">
       <div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:14px;flex-wrap:wrap;gap:8px">
         <h3 style="margin:0">Hardware Inspector</h3>
@@ -431,6 +491,36 @@
       <button class="btn-del" style="padding:12px;border-radius:6px;font-size:1rem" onclick="modalAction('erase')">Revert to Expected</button>
       <button class="btn" style="background:none;color:#888;border:1px solid #555" onclick="closeModal()">Cancel</button>
     </div>
+  </div>
+</div>
+
+<!-- UNIVERSAL FIRMWARE DIAGNOSTICS MODAL -->
+<div class="modal-overlay" id="universalDiagnosticsModal">
+  <div class="modal-content provision-diagnostics-modal">
+    <div class="provision-modal-header">
+      <div>
+        <h3 id="universalDiagnosticsTitle">Module Diagnostics</h3>
+        <div id="universalDiagnosticsSubtitle"></div>
+      </div>
+      <button class="provision-modal-close" onclick="closeUniversalDiagnostics()" aria-label="Close">×</button>
+    </div>
+    <div id="universalDiagnosticsBody">
+      <div class="provision-empty">Choose a diagnostic test.</div>
+    </div>
+    <div class="provision-diagnostic-actions">
+      <button class="btn btn-secondary btn-sm" onclick="runUniversalDiagnostic('snapshot')">
+        <i data-lucide="activity" style="width:14px;height:14px"></i> Health Snapshot
+      </button>
+      <button class="btn btn-secondary btn-sm" onclick="runUniversalDiagnostic('hall')">
+        <i data-lucide="magnet" style="width:14px;height:14px"></i> Hall Test
+      </button>
+      <button class="btn btn-warning btn-sm" onclick="runUniversalDiagnostic('mechanical')">
+        <i data-lucide="rotate-cw" style="width:14px;height:14px"></i> Mechanical Test
+      </button>
+    </div>
+    <p class="provision-diagnostic-warning">
+      Hall and mechanical tests move the reel. The mechanical test runs at least five revolutions and can take about 30 seconds.
+    </p>
   </div>
 </div>
 

--- a/server/templates/index.html
+++ b/server/templates/index.html
@@ -238,7 +238,18 @@
 
         <details class="provision-danger">
           <summary>Advanced: de-provision all modules</summary>
-          <p>This erases every module ID on the bus. Calibration data is preserved, but every module must be assigned again.</p>
+          <p>
+            This erases every module ID on the bus. Calibration data is preserved,
+            but every module must be assigned again.
+          </p>
+          <p class="provision-danger-warning">
+            <strong>Large displays:</strong> If more than roughly 10–15 modules are
+            unprovisioned at once, their periodic advertisements may overlap on the
+            shared RS-485 bus and make discovery unreliable. Provision in batches:
+            temporarily power off or disconnect enough modules to leave about
+            10–15 unprovisioned modules connected, assign IDs to that batch, then
+            reconnect the next group.
+          </p>
           <button class="btn-del" onclick="deprovisionAllUniversalModules()">De-provision All Modules</button>
         </details>
       </div>

--- a/tests/test_universal_firmware.py
+++ b/tests/test_universal_firmware.py
@@ -1,0 +1,165 @@
+import pathlib
+import sys
+import threading
+import time
+import unittest
+
+
+SERVER_DIR = pathlib.Path(__file__).resolve().parents[1] / "server"
+sys.path.insert(0, str(SERVER_DIR))
+
+from hardware.universal_firmware import (  # noqa: E402
+    UniversalFirmwareManager,
+    parse_universal_line,
+)
+
+
+SERIAL_NUMBER = "A3F24C0018E7D29B3F01"
+
+
+class FakeSerial:
+    def __init__(self):
+        self.is_open = True
+        self.writes = []
+
+    def write(self, payload):
+        self.writes.append(payload)
+        return len(payload)
+
+    def flush(self):
+        pass
+
+
+class ProtocolParserTests(unittest.TestCase):
+    def test_parses_advertisement_and_both_ack_formats(self):
+        self.assertEqual(
+            parse_universal_line("mXadv:" + SERIAL_NUMBER),
+            {"type": "advertisement", "serial": SERIAL_NUMBER},
+        )
+        expected = {"type": "ack", "serial": SERIAL_NUMBER, "id": 38}
+        self.assertEqual(
+            parse_universal_line("mXack:" + SERIAL_NUMBER + ":38"),
+            expected,
+        )
+        self.assertEqual(
+            parse_universal_line("mXack" + SERIAL_NUMBER + ":38"),
+            expected,
+        )
+
+    def test_parses_current_version_and_diagnostic_frames(self):
+        version = parse_universal_line(
+            "m38v:29:38:" + SERIAL_NUMBER
+        )
+        self.assertTrue(version["universal"])
+        self.assertEqual(version["reported_id"], 38)
+        self.assertEqual(version["firmware"], "29")
+
+        snapshot = parse_universal_line("m38Q:8:12:4930:1:-1")
+        self.assertEqual(snapshot["reset_cause"], 8)
+        self.assertEqual(snapshot["current_index"], -1)
+
+        hall = parse_universal_line("m38T:0:1:168:1")
+        self.assertEqual(hall["falling_edges"], 1)
+
+        mechanical = parse_universal_line(
+            "m38M:0:4095:4097:1:168:4500:167:4096,4095,4097,4096,4096"
+        )
+        self.assertEqual(mechanical["average_magnet_width"], 167)
+        self.assertEqual(mechanical["revolutions"], [4096, 4095, 4097, 4096, 4096])
+
+
+class ManagerCommandTests(unittest.TestCase):
+    def setUp(self):
+        self.serial = FakeSerial()
+        self.manager = UniversalFirmwareManager(
+            get_serial=lambda: self.serial,
+            serial_lock=threading.Lock(),
+            get_sim_mode=lambda: False,
+        )
+
+    def test_commands_match_provision_py_examples(self):
+        self.manager.home_by_serial(SERIAL_NUMBER)
+        self.manager.home_module(38)
+        self.manager.deprovision(38)
+        self.manager.deprovision_all()
+        self.manager.scan(44)
+
+        self.assertEqual(
+            self.serial.writes,
+            [
+                ("mXH" + SERIAL_NUMBER + "\n").encode("ascii"),
+                b"m38h\n",
+                b"m38R\n",
+                b"m*R\n",
+                b"m*v0-44\n",
+            ],
+        )
+
+    def test_fragmented_serial_reads_are_reassembled(self):
+        self.manager.feed_bytes(b"mXadv:A3F24C0018E7")
+        self.manager.feed_bytes(b"D29B3F01\nm4v:29:4:B10055")
+        self.manager.feed_bytes(b"FFA3C2918D7E44\n")
+
+        status = self.manager.status(module_limit=45)
+        self.assertEqual(
+            [item["serial"] for item in status["unprovisioned"]],
+            [SERIAL_NUMBER],
+        )
+        self.assertEqual(status["modules"][0]["id"], 4)
+        self.assertEqual(status["modules"][0]["firmware_number"], 29)
+
+    def test_provision_waits_for_ack_and_queries_version(self):
+        def acknowledge():
+            deadline = time.time() + 1
+            while not self.serial.writes and time.time() < deadline:
+                time.sleep(0.005)
+            self.manager.handle_line("mXack" + SERIAL_NUMBER + ":7")
+
+        thread = threading.Thread(target=acknowledge)
+        thread.start()
+        acknowledged = self.manager.provision(SERIAL_NUMBER, 7, timeout=0.5)
+        thread.join()
+
+        self.assertTrue(acknowledged)
+        self.assertEqual(
+            self.serial.writes,
+            [
+                ("mXI" + SERIAL_NUMBER + ":7\n").encode("ascii"),
+                b"m7v\n",
+            ],
+        )
+
+    def test_mechanical_count_is_only_sent_to_v29_or_newer(self):
+        self.manager.handle_line("m3v:28:3:" + SERIAL_NUMBER)
+
+        def answer_v28():
+            deadline = time.time() + 1
+            while not self.serial.writes and time.time() < deadline:
+                time.sleep(0.005)
+            self.manager.handle_line("m3M:0:4096:4096:0:168:4500")
+
+        thread = threading.Thread(target=answer_v28)
+        thread.start()
+        result = self.manager.run_diagnostic(3, "mechanical", revolutions=8)
+        thread.join()
+        self.assertEqual(self.serial.writes[-1], b"m3M\n")
+        self.assertEqual(result["type"], "mechanical")
+
+        self.serial.writes.clear()
+        self.manager.handle_line("m3v:29:3:" + SERIAL_NUMBER)
+
+        def answer_v29():
+            deadline = time.time() + 1
+            while not self.serial.writes and time.time() < deadline:
+                time.sleep(0.005)
+            self.manager.handle_line("m3M:0:4096:4096:0:168:4500")
+
+        thread = threading.Thread(target=answer_v29)
+        thread.start()
+        self.manager.run_diagnostic(3, "mechanical", revolutions=8)
+        thread.join()
+        self.assertEqual(self.serial.writes[-1], b"m3M8\n")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_universal_firmware.py
+++ b/tests/test_universal_firmware.py
@@ -21,13 +21,41 @@ class FakeSerial:
     def __init__(self):
         self.is_open = True
         self.writes = []
+        self.write_hook = None
+        self.read_count = 0
+        self._rx = bytearray()
+        self._lock = threading.Lock()
 
     def write(self, payload):
         self.writes.append(payload)
+        if self.write_hook:
+            self.write_hook(payload, self)
         return len(payload)
 
     def flush(self):
         pass
+
+    def queue_read(self, payload):
+        if isinstance(payload, str):
+            payload = payload.encode("ascii")
+        with self._lock:
+            self._rx.extend(payload)
+
+    @property
+    def in_waiting(self):
+        with self._lock:
+            return len(self._rx)
+
+    def read(self, size=1):
+        with self._lock:
+            self.read_count += 1
+            chunk = bytes(self._rx[:size])
+            del self._rx[:size]
+            return chunk
+
+    def reset_input_buffer(self):
+        with self._lock:
+            self._rx.clear()
 
 
 class ProtocolParserTests(unittest.TestCase):
@@ -77,21 +105,31 @@ class ManagerCommandTests(unittest.TestCase):
             get_sim_mode=lambda: False,
         )
 
+    def tearDown(self):
+        self.manager.stop()
+
+    def wait_for_writes(self, count, timeout=1.0):
+        deadline = time.time() + timeout
+        while len(self.serial.writes) < count and time.time() < deadline:
+            time.sleep(0.005)
+        self.assertGreaterEqual(len(self.serial.writes), count)
+
     def test_commands_match_provision_py_examples(self):
         self.manager.home_by_serial(SERIAL_NUMBER)
         self.manager.home_module(38)
         self.manager.deprovision(38)
         self.manager.deprovision_all()
-        self.manager.scan(44)
+        self.manager.scan(0)
+        self.wait_for_writes(5)
 
         self.assertEqual(
-            self.serial.writes,
+            self.serial.writes[:5],
             [
                 ("mXH" + SERIAL_NUMBER + "\n").encode("ascii"),
                 b"m38h\n",
                 b"m38R\n",
                 b"m*R\n",
-                b"m*v0-44\n",
+                b"m*v0-0\n",
             ],
         )
 
@@ -109,16 +147,14 @@ class ManagerCommandTests(unittest.TestCase):
         self.assertEqual(status["modules"][0]["firmware_number"], 29)
 
     def test_provision_waits_for_ack_and_queries_version(self):
-        def acknowledge():
-            deadline = time.time() + 1
-            while not self.serial.writes and time.time() < deadline:
-                time.sleep(0.005)
-            self.manager.handle_line("mXack" + SERIAL_NUMBER + ":7")
+        def respond(payload, serial_port):
+            if payload == ("mXI" + SERIAL_NUMBER + ":7\n").encode("ascii"):
+                serial_port.queue_read("mXack" + SERIAL_NUMBER + ":7\n")
+            elif payload == b"m7v\n":
+                serial_port.queue_read("m7v:29:7:" + SERIAL_NUMBER + "\n")
 
-        thread = threading.Thread(target=acknowledge)
-        thread.start()
+        self.serial.write_hook = respond
         acknowledged = self.manager.provision(SERIAL_NUMBER, 7, timeout=0.5)
-        thread.join()
 
         self.assertTrue(acknowledged)
         self.assertEqual(
@@ -128,37 +164,86 @@ class ManagerCommandTests(unittest.TestCase):
                 b"m7v\n",
             ],
         )
+        status = self.manager.status(module_limit=45)
+        self.assertEqual(status["modules"][0]["id"], 7)
+        self.assertEqual(status["modules"][0]["firmware_number"], 29)
 
     def test_mechanical_count_is_only_sent_to_v29_or_newer(self):
         self.manager.handle_line("m3v:28:3:" + SERIAL_NUMBER)
 
-        def answer_v28():
-            deadline = time.time() + 1
-            while not self.serial.writes and time.time() < deadline:
-                time.sleep(0.005)
-            self.manager.handle_line("m3M:0:4096:4096:0:168:4500")
+        def answer_mechanical(payload, serial_port):
+            if payload in (b"m3M\n", b"m3M8\n"):
+                serial_port.queue_read("m3M:0:4096:4096:0:168:4500\n")
 
-        thread = threading.Thread(target=answer_v28)
-        thread.start()
+        self.serial.write_hook = answer_mechanical
         result = self.manager.run_diagnostic(3, "mechanical", revolutions=8)
-        thread.join()
         self.assertEqual(self.serial.writes[-1], b"m3M\n")
         self.assertEqual(result["type"], "mechanical")
 
         self.serial.writes.clear()
         self.manager.handle_line("m3v:29:3:" + SERIAL_NUMBER)
 
-        def answer_v29():
-            deadline = time.time() + 1
-            while not self.serial.writes and time.time() < deadline:
-                time.sleep(0.005)
-            self.manager.handle_line("m3M:0:4096:4096:0:168:4500")
-
-        thread = threading.Thread(target=answer_v29)
-        thread.start()
         self.manager.run_diagnostic(3, "mechanical", revolutions=8)
-        thread.join()
         self.assertEqual(self.serial.writes[-1], b"m3M8\n")
+
+    def test_transaction_owns_the_serial_lock_until_response_is_read(self):
+        lock = threading.Lock()
+        self.manager = UniversalFirmwareManager(
+            get_serial=lambda: self.serial,
+            serial_lock=lock,
+            get_sim_mode=lambda: False,
+        )
+
+        def respond(payload, serial_port):
+            self.assertTrue(lock.locked())
+            serial_port.queue_read("m4Q:0:2:3312:1:12\n")
+
+        self.serial.write_hook = respond
+        result = self.manager.run_diagnostic(4, "snapshot")
+
+        self.assertEqual(result["type"], "snapshot")
+        self.assertEqual(result["vcc_mv"], 3312)
+        self.assertGreater(self.serial.read_count, 0)
+
+    def test_passive_reader_backs_off_while_another_transaction_owns_lock(self):
+        lock = threading.Lock()
+        self.manager = UniversalFirmwareManager(
+            get_serial=lambda: self.serial,
+            serial_lock=lock,
+            get_sim_mode=lambda: False,
+        )
+        self.serial.queue_read("mXadv:" + SERIAL_NUMBER + "\n")
+
+        lock.acquire()
+        try:
+            self.manager.ensure_started()
+            time.sleep(0.05)
+            self.assertEqual(self.serial.read_count, 0)
+        finally:
+            lock.release()
+
+        deadline = time.time() + 1
+        while self.serial.read_count == 0 and time.time() < deadline:
+            time.sleep(0.01)
+
+        self.assertGreater(self.serial.read_count, 0)
+        self.assertEqual(
+            [item["serial"] for item in self.manager.status()["unprovisioned"]],
+            [SERIAL_NUMBER],
+        )
+
+    def test_status_filters_expired_advertisements_without_mutating_state(self):
+        self.manager.handle_line("mXadv:" + SERIAL_NUMBER)
+        with self.manager._condition:
+            self.manager._unprovisioned[SERIAL_NUMBER]["last_seen"] -= (
+                self.manager.ADVERTISEMENT_TTL_SECONDS + 1
+            )
+
+        status = self.manager.status(module_limit=45)
+
+        self.assertEqual(status["unprovisioned"], [])
+        with self.manager._condition:
+            self.assertIn(SERIAL_NUMBER, self.manager._unprovisioned)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Introduce end-to-end Universal Firmware provisioning and diagnostics.

- Add a UniversalFirmwareManager (server/hardware/universal_firmware.py) that passively observes the RS-485 bus, parses firmware messages, tracks provisioned/unprovisioned modules, and issues provisioning/diagnostic commands. Includes background reader, synchronization with the app's serial lock, simulation-mode checks, and user-facing UniversalFirmwareError.
- Wire manager into the backend (server/app.py): start/reset manager with serial port changes and expose REST endpoints: /universal/status, /universal/scan, /universal/home, /universal/provision, /universal/deprovision, /universal/diagnose with error handling and appropriate response codes.
- Add frontend UI pieces (server/static/app.js, server/static/styles.css, server/templates/index.html) to show provisioning card on the Calibration page: scan, identify, assign IDs, deprovision, run diagnostics, and render results; includes polling and simulated-mode safeguards.
- Update README with documentation and links for Universal Firmware and acknowledge upstream work.
- Add a test scaffold (tests/test_universal_firmware.py) for the new manager.

<img width="822" height="939" alt="image" src="https://github.com/user-attachments/assets/086849a8-6b98-4c30-a9b3-48e11a416253" />

Deprovision all warning 
<img width="842" height="244" alt="image" src="https://github.com/user-attachments/assets/c0fc185a-e43f-48d4-9490-3c8c4c8340b6" />


### Collapsed view
<img width="848" height="290" alt="image" src="https://github.com/user-attachments/assets/d65370cc-1ef0-41d7-99c1-590878cd6420" />


These changes enable discovery, ID assignment, diagnostics, and de-provisioning of modules running the universal firmware from the Calibration UI.