### PR TITLE
Fix calibration adjustments to move immediately

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -14,6 +14,7 @@ import urllib.request
 import shutil
 from datetime import datetime
 from flask import Flask, render_template, request, jsonify
+from tuning import build_tuning_adjust_commands
 
 try:
     import paho.mqtt.client as mqtt
@@ -2142,10 +2143,26 @@ def auto_tune_route():
                 settings['tuned_chars'][mod_str] = {}
             settings['tuned_chars'][mod_str][str(char_idx)] = new_val
 
-            # Write to firmware EEPROM
-            send_raw(f"m{mod_id:02d}w{char_idx}:{new_val}")
+            # Save the tuned position, then move there immediately so the user
+            # can see the compensation. The preview uses firmware `g`, the
+            # absolute motor-step GOTO command also used by Custom Tune's Test
+            # Position flow; re-sending the same flap index could be ignored
+            # because firmware still considers that character index active.
+            save_command, preview_command = build_tuning_adjust_commands(
+                mod_id,
+                char_idx,
+                new_val,
+                cal,
+            )
+            send_raw(save_command)
+            send_raw(preview_command)
 
-            adjusted.append({'module': mod_id, 'old': base, 'new': new_val})
+            adjusted.append({
+                'module': mod_id,
+                'old': base,
+                'new': new_val,
+                'previewed': True,
+            })
 
         save_settings(settings)
         return jsonify(status="ok", adjusted=adjusted)

--- a/server/static/app.js
+++ b/server/static/app.js
@@ -2685,12 +2685,6 @@ async function atApplyAhead(){
   showToast(`Applied −${step} to ${modules.length} modules`);
   at.selected.clear();
 
-  // Re-send all to this char to verify
-  await fetch('/auto_tune', {
-    method:'POST', headers:{'Content-Type':'application/json'},
-    body: JSON.stringify({action:'goto_char', char_index: at.charIndex})
-  });
-
   // Refresh positions
   const res = await fetch('/auto_tune', {
     method:'POST', headers:{'Content-Type':'application/json'},
@@ -2723,12 +2717,6 @@ async function atApplyBehind(){
 
   showToast(`Applied +${step} to ${modules.length} modules`);
   at.selected.clear();
-
-  // Re-send to verify
-  await fetch('/auto_tune', {
-    method:'POST', headers:{'Content-Type':'application/json'},
-    body: JSON.stringify({action:'goto_char', char_index: at.charIndex})
-  });
 
   // Refresh positions
   const res = await fetch('/auto_tune', {
@@ -2881,11 +2869,6 @@ async function tmNudge(multiplier){
 
   tm.adjustedChars.add(tm.charIdx);
   showToast(`Applied ${delta>0?'+':''}${delta} to ${modules.length} modules`);
-
-  await fetch('/auto_tune', {
-    method:'POST', headers:{'Content-Type':'application/json'},
-    body: JSON.stringify({action:'goto_char', char_index: tm.charIdx})
-  });
 
   const res = await fetch('/auto_tune', {
     method:'POST', headers:{'Content-Type':'application/json'},

--- a/server/templates/index.html
+++ b/server/templates/index.html
@@ -467,7 +467,7 @@
       <div style="margin:14px 0">
         <label class="field-label">Step Adjustment Size</label>
         <input type="number" id="atStepSize" value="25" min="1" max="100" class="at-step-input" style="width:100%">
-        <div style="color:#666;font-size:.75rem;margin-top:4px">Default 25 steps (~40% of one character spacing). Increase for larger errors.</div>
+        <div style="color:#666;font-size:.75rem;margin-top:4px">Default 25 steps (~40% of one character spacing). Applying a correction moves selected modules immediately; a negative correction may require one full forward revolution.</div>
       </div>
       <div style="margin:14px 0">
         <label class="field-label">Start from character index</label>
@@ -542,7 +542,7 @@
       <div style="margin:14px 0">
         <label class="field-label">Step Size</label>
         <input type="number" id="tmStepSize" value="3" min="1" max="100" class="at-step-input" style="width:100%">
-        <div style="color:#666;font-size:.75rem;margin-top:4px">Steps per nudge click. Smaller = more precise.</div>
+        <div style="color:#666;font-size:.75rem;margin-top:4px">Steps per nudge click. Selected modules move immediately so you can see each correction; negative nudges may make one full forward revolution.</div>
       </div>
       <div style="display:flex;gap:8px;margin-top:16px">
         <button class="btn btn-success" style="flex:1" onclick="tmBegin()">Home All &amp; Begin</button>

--- a/server/tuning.py
+++ b/server/tuning.py
@@ -1,0 +1,40 @@
+"""Pure helpers for fine-tuning hardware commands."""
+
+
+def build_tuning_adjust_commands(
+    module_id,
+    char_index,
+    step_position,
+    calibration_steps,
+):
+    """Return commands that save and immediately preview a tuned position.
+
+    The preview command intentionally uses firmware ``g`` ("goto absolute
+    motor step position"), not character-index navigation. Fine-tuning changes
+    the physical step for the currently displayed character; asking firmware to
+    go to the same character index again may be ignored because the logical flap
+    index has not changed.
+    """
+
+    module_id = int(module_id)
+    char_index = int(char_index)
+    step_position = int(step_position)
+    calibration_steps = int(calibration_steps)
+
+    if module_id < 0 or module_id > 254:
+        raise ValueError("Module ID must be between 0 and 254.")
+    if char_index < 0 or char_index > 63:
+        raise ValueError("Character index must be between 0 and 63.")
+    if calibration_steps <= 0:
+        raise ValueError("Calibration steps must be positive.")
+    if step_position < 0:
+        raise ValueError("Step position cannot be negative.")
+    if step_position >= calibration_steps:
+        raise ValueError(
+            f"Step position must be less than calibration steps ({calibration_steps})."
+        )
+
+    return (
+        f"m{module_id:02d}w{char_index}:{step_position}",
+        f"m{module_id:02d}g{step_position}",
+    )

--- a/tests/test_tuning.py
+++ b/tests/test_tuning.py
@@ -1,0 +1,44 @@
+import pathlib
+import sys
+import unittest
+
+
+SERVER_DIR = pathlib.Path(__file__).resolve().parents[1] / "server"
+sys.path.insert(0, str(SERVER_DIR))
+
+from tuning import build_tuning_adjust_commands  # noqa: E402
+
+
+class TuningCommandTests(unittest.TestCase):
+    def test_adjustment_is_saved_and_immediately_previewed(self):
+        self.assertEqual(
+            build_tuning_adjust_commands(3, 51, 2618, 4096),
+            ("m03w51:2618", "m03g2618"),
+        )
+
+    def test_preview_uses_absolute_step_position_not_character_index(self):
+        _, preview_command = build_tuning_adjust_commands(3, 51, 2618, 4096)
+        self.assertEqual(preview_command, "m03g2618")
+        self.assertNotEqual(preview_command, "m03g51")
+
+    def test_allows_last_valid_step_for_calibration(self):
+        self.assertEqual(
+            build_tuning_adjust_commands(3, 51, 4095, 4096),
+            ("m03w51:4095", "m03g4095"),
+        )
+
+    def test_rejects_invalid_values(self):
+        with self.assertRaises(ValueError):
+            build_tuning_adjust_commands(-1, 10, 500, 4096)
+        with self.assertRaises(ValueError):
+            build_tuning_adjust_commands(1, 64, 500, 4096)
+        with self.assertRaises(ValueError):
+            build_tuning_adjust_commands(1, 10, 500, 0)
+        with self.assertRaises(ValueError):
+            build_tuning_adjust_commands(1, 10, -1, 4096)
+        with self.assertRaises(ValueError):
+            build_tuning_adjust_commands(1, 10, 4096, 4096)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This pull request refactors how fine-tuning adjustments are sent to hardware modules, ensuring that after a correction is applied, the module immediately moves to the new position for user feedback. It introduces a helper function for building adjustment commands, updates the backend to use this helper, removes redundant client-side requests, and adds tests for the new logic. User-facing descriptions have also been updated for clarity.

**Backend improvements:**

* Added a new helper function `build_tuning_adjust_commands` in `tuning.py` to generate commands that both save a tuning adjustment and immediately preview it by moving the module.
* Updated `auto_tune_route` in `server/app.py` to use the new helper, ensuring that after an adjustment, the module is moved immediately for feedback. The response now also indicates that the adjustment was previewed.
* Added unit tests in `tests/test_tuning.py` to verify that `build_tuning_adjust_commands` generates the correct commands and properly validates input.

**Frontend changes:**

* Removed unnecessary client-side requests in `app.js` that previously re-sent the same character index after an adjustment, since the backend now handles immediate previewing. [[1]](diffhunk://#diff-b00398f81bc55184de2a858bf419d242def77cfe797a17b7d3b5b54b62cef5c1L2624-L2629) [[2]](diffhunk://#diff-b00398f81bc55184de2a858bf419d242def77cfe797a17b7d3b5b54b62cef5c1L2663-L2668) [[3]](diffhunk://#diff-b00398f81bc55184de2a858bf419d242def77cfe797a17b7d3b5b54b62cef5c1L2821-L2825)

**User interface updates:**

* Updated instructional text in `index.html` to clarify that corrections now move modules immediately, and that negative corrections may require a full forward revolution. [[1]](diffhunk://#diff-6d6d80a34fdd2395df72772d5d368c9837e87b92b5074cdd4b99547aa8abaa05L441-R441) [[2]](diffhunk://#diff-6d6d80a34fdd2395df72772d5d368c9837e87b92b5074cdd4b99547aa8abaa05L516-R516)